### PR TITLE
Remove lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38692,18 +38692,16 @@
       }
     },
     "packages/remix-forms": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^2.8.8",
-        "lodash": "^4.17.21",
         "react-hook-form": "^7.27.1"
       },
       "devDependencies": {
         "@remix-run/dev": "^1.4.1",
         "@remix-run/node": "^1.4.1",
         "@remix-run/react": "^1.4.1",
-        "@types/lodash": "^4.14.181",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
         "c8": "^7.11.2",
@@ -62831,13 +62829,11 @@
         "@remix-run/dev": "^1.4.1",
         "@remix-run/node": "^1.4.1",
         "@remix-run/react": "^1.4.1",
-        "@types/lodash": "^4.14.181",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
         "c8": "^7.11.2",
         "eslint": "^7.32.0",
         "eslint-config-custom": "*",
-        "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-hook-form": "^7.27.1",
         "tsconfig": "*",

--- a/packages/remix-forms/package.json
+++ b/packages/remix-forms/package.json
@@ -22,7 +22,6 @@
     "@remix-run/dev": "^1.4.1",
     "@remix-run/node": "^1.4.1",
     "@remix-run/react": "^1.4.1",
-    "@types/lodash": "^4.14.181",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "c8": "^7.11.2",
@@ -36,7 +35,6 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^2.8.8",
-    "lodash": "^4.17.21",
     "react-hook-form": "^7.27.1"
   }
 }

--- a/packages/remix-forms/src/Form.tsx
+++ b/packages/remix-forms/src/Form.tsx
@@ -23,7 +23,6 @@ import defaultRenderField from './defaultRenderField'
 import { Fetcher } from '@remix-run/react'
 import inferLabel from './inferLabel'
 import { shapeInfo, ZodTypeName } from './shapeInfo'
-import { concat } from 'lodash/fp'
 import { Transition } from '@remix-run/react/dist/transition'
 
 export type Field<SchemaType> = {
@@ -308,7 +307,7 @@ export function Form<Schema extends SomeZodObject>({
 
     const fieldOptions =
       rawOptions && !required
-        ? concat([{ name: '', value: '' }], rawOptions)
+        ? ([{ name: '', value: '' }, ...(rawOptions ?? [])] as Option[])
         : rawOptions
 
     const label = (labels && labels[key]) || inferLabel(String(stringKey))

--- a/packages/remix-forms/src/formAction.server.ts
+++ b/packages/remix-forms/src/formAction.server.ts
@@ -1,5 +1,4 @@
 import { json, redirect } from '@remix-run/server-runtime'
-import { concat } from 'lodash/fp'
 import { DomainFunction, errorMessagesForSchema } from 'remix-domains'
 import { SomeZodObject, z } from 'zod'
 import getFormValues from './getFormValues'
@@ -60,7 +59,7 @@ export async function performMutation<
         ...errorMessagesForSchema(result.inputErrors, schema),
         _global:
           result.errors.length || result.environmentErrors.length
-            ? concat(result.errors, result.environmentErrors).map(
+            ? [...result.errors, ...result.environmentErrors].map(
                 (error) => error.message,
               )
             : undefined,

--- a/packages/remix-forms/src/inferLabel.ts
+++ b/packages/remix-forms/src/inferLabel.ts
@@ -1,4 +1,4 @@
-import { startCase } from 'lodash/fp'
+import startCase from './startCase'
 
 export default function inferLabel(fieldName: string) {
   return startCase(fieldName).replace(/Url/g, 'URL')

--- a/packages/remix-forms/src/startCase.test.ts
+++ b/packages/remix-forms/src/startCase.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import startCase from './startCase'
+
+describe('startCase', () => {
+  it('capitalizes the first letter of every word', () => {
+    const strings = [
+      'some_field_name',
+      'Some field that needs to be title-cased',
+      'some-field-name',
+      'some-mixed_string with spaces_underscores-and-hyphens',
+    ]
+    expect(strings.map(startCase)).toEqual([
+      'Some Field Name',
+      'Some Field That Needs To Be Title Cased',
+      'Some Field Name',
+      'Some Mixed String With Spaces Underscores And Hyphens',
+    ])
+  })
+})

--- a/packages/remix-forms/src/startCase.ts
+++ b/packages/remix-forms/src/startCase.ts
@@ -1,0 +1,8 @@
+// source: https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/toTitleCase.md
+
+export default function startCase(str: string): string {
+  const matches = str.match(
+    /[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g,
+  ) ?? ['']
+  return matches.map((x) => x.charAt(0).toUpperCase() + x.slice(1)).join(' ')
+}


### PR DESCRIPTION
As @tavoyne pointed out on #62 , lodash is taking up to 48% of remix-forms' package size (over 67kb 😱).

I started playing with this PR by using the
```ts
import startCase from 'lodash/startCase'
```
syntax so it would already reduce the bundle size but ended up completely replacing lodash's `startCase` with a [custom (yet well tested) version of `startCase`](https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/toTitleCase.md) and replacing `concat` with the native ES6's array spread.

This way we'll have only 2 dependencies if this PR is merged: `react-hook-form` and `@hookform/resolvers`.