### PR TITLE
Global eslint config

### DIFF
--- a/apps/web/.eslintrc
+++ b/apps/web/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["@remix-run/eslint-config", "@remix-run/eslint-config/node"]
-}

--- a/apps/web/app/helpers.ts
+++ b/apps/web/app/helpers.ts
@@ -1,5 +1,5 @@
 import { compose, join, reject, isBoolean, isNil, flatten } from 'lodash/fp'
-import { HtmlMetaDescriptor } from '@remix-run/node'
+import type { HtmlMetaDescriptor } from '@remix-run/node'
 
 const cx = (...args: unknown[]) =>
   compose(join(' '), reject(isBoolean), reject(isNil), flatten)(args)

--- a/apps/web/app/routes/conf/01.tsx
+++ b/apps/web/app/routes/conf/01.tsx
@@ -1,10 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'

--- a/apps/web/app/routes/conf/02.tsx
+++ b/apps/web/app/routes/conf/02.tsx
@@ -1,11 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'

--- a/apps/web/app/routes/conf/03.tsx
+++ b/apps/web/app/routes/conf/03.tsx
@@ -1,11 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'

--- a/apps/web/app/routes/conf/04.tsx
+++ b/apps/web/app/routes/conf/04.tsx
@@ -1,11 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'

--- a/apps/web/app/routes/conf/05.tsx
+++ b/apps/web/app/routes/conf/05.tsx
@@ -1,11 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'

--- a/apps/web/app/routes/conf/06.tsx
+++ b/apps/web/app/routes/conf/06.tsx
@@ -1,11 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'

--- a/apps/web/app/routes/conf/07.tsx
+++ b/apps/web/app/routes/conf/07.tsx
@@ -1,11 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
-  redirect,
 } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import Input from '~/ui/input'
@@ -376,6 +375,7 @@ export default function Component() {
 
     const field = fields.find((name) => serverErrorFor(name))
     field && setFocus(field)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverErrors])
 
   return (

--- a/apps/web/app/routes/conf/08.tsx
+++ b/apps/web/app/routes/conf/08.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import { z } from 'zod'

--- a/apps/web/app/routes/conf/09.tsx
+++ b/apps/web/app/routes/conf/09.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Example from '~/ui/example'
 import { z } from 'zod'

--- a/apps/web/app/routes/conf/index.tsx
+++ b/apps/web/app/routes/conf/index.tsx
@@ -1,4 +1,4 @@
-import { MetaFunction } from '@remix-run/node'
+import type { MetaFunction } from '@remix-run/node'
 import { metaTags } from '~/helpers'
 import Heading from '~/ui/heading'
 import SubHeading from '~/ui/sub-heading'
@@ -34,11 +34,11 @@ export default function Component() {
         </div>
         <dl className="flex flex-[2] flex-col space-y-8">
           <Feature icon={ClipboardListIcon} title="A great form UI takes work">
-            First, we'll walk you through the creation of a great form UI from
-            scratch.
+            First, we&apos;ll walk you through the creation of a great form UI
+            from scratch.
           </Feature>
           <Feature icon={SparklesIcon} title="We do the work for you">
-            Then, we'll show you how Remix Forms does all the work for you.
+            Then, we&apos;ll show you how Remix Forms does all the work for you.
           </Feature>
           <Feature icon={GiftIcon} title="With a powerful DX">
             <ExternalLink href="https://github.com/SeasonedSoftware/remix-forms-site/tree/main/app/routes/conf">
@@ -56,7 +56,7 @@ export default function Component() {
         .
       </p>
       <div className="flex justify-center">
-        <ButtonLink to="01">Let's Start</ButtonLink>
+        <ButtonLink to="01">Let&apos;s Start</ButtonLink>
       </div>
     </div>
   )

--- a/apps/web/app/routes/conf/success.$referrer.tsx
+++ b/apps/web/app/routes/conf/success.$referrer.tsx
@@ -10,7 +10,7 @@ export default function Component() {
     <div className="flex flex-col space-y-8 p-8 text-center sm:space-y-16 sm:p-16">
       <Heading>Success! 🎉</Heading>
       <SubHeading>
-        You've been redirected here from our successful form!
+        You&apos;ve been redirected here from our successful form!
       </SubHeading>
       <ButtonLink to={`../${referrer}`}>Go back</ButtonLink>
     </div>

--- a/apps/web/app/routes/examples/actions/custom-response.tsx
+++ b/apps/web/app/routes/examples/actions/custom-response.tsx
@@ -1,10 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
 } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { performMutation } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/actions/environment.tsx
+++ b/apps/web/app/routes/examples/actions/environment.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'
@@ -66,7 +70,7 @@ export default function Component() {
       title={title}
       description={
         <>
-          In this example, we use Remix Domain's{' '}
+          In this example, we use Remix Domain&apos;s{' '}
           <ExternalLink href="https://github.com/SeasonedSoftware/remix-domains#taking-parameters-that-are-not-user-input">
             environment
           </ExternalLink>{' '}

--- a/apps/web/app/routes/examples/actions/field-error.tsx
+++ b/apps/web/app/routes/examples/actions/field-error.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/actions/global-error.tsx
+++ b/apps/web/app/routes/examples/actions/global-error.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/actions/without-redirect.tsx
+++ b/apps/web/app/routes/examples/actions/without-redirect.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/async-validation.tsx
+++ b/apps/web/app/routes/examples/forms/async-validation.tsx
@@ -1,10 +1,10 @@
 import hljs from 'highlight.js/lib/common'
-import {
+import type {
   ActionFunction,
-  json,
   LoaderFunction,
   MetaFunction,
 } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/auto-generated.tsx
+++ b/apps/web/app/routes/examples/forms/auto-generated.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/custom-input.tsx
+++ b/apps/web/app/routes/examples/forms/custom-input.tsx
@@ -35,7 +35,7 @@ export default () => (
               <input
                 type="email"
                 {...register('email')}
-                className="border-2 border-dashed rounded-md"
+                className="rounded-md border-2 border-dashed"
               />
               <Errors />
             </>

--- a/apps/web/app/routes/examples/forms/custom-input.tsx
+++ b/apps/web/app/routes/examples/forms/custom-input.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'
@@ -68,7 +72,7 @@ export default function Component() {
           <ExternalLink href="https://react-hook-form.com/">
             react-hook-form
           </ExternalLink>
-          's <em>register</em> function.
+          &apos;s <em>register</em> function.
         </>
       }
     >
@@ -83,7 +87,7 @@ export default function Component() {
                   <input
                     type="email"
                     {...register('email')}
-                    className="border-2 border-dashed rounded-md"
+                    className="rounded-md border-2 border-dashed"
                   />
                   <Errors />
                 </>

--- a/apps/web/app/routes/examples/forms/edit-values.tsx
+++ b/apps/web/app/routes/examples/forms/edit-values.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/field-layout.tsx
+++ b/apps/web/app/routes/examples/forms/field-layout.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/field-with-children.tsx
+++ b/apps/web/app/routes/examples/forms/field-with-children.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'
@@ -65,7 +69,7 @@ export default function Component() {
               {({ Label, SmartInput, Errors }) => (
                 <>
                   <Label>E-mail</Label>
-                  <em>You'll hear from us at this address 👇🏽</em>
+                  <em>You&apos;ll hear from us at this address 👇🏽</em>
                   <SmartInput />
                   <Errors />
                 </>

--- a/apps/web/app/routes/examples/forms/form-with-children.tsx
+++ b/apps/web/app/routes/examples/forms/form-with-children.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'
@@ -70,7 +74,7 @@ export default function Component() {
             <Field name="csrfToken" value="abc123" hidden />
             <Field name="firstName" placeholder="Your first name" />
             <Field name="email" label="E-mail" placeholder="Your e-mail" />
-            <em>You'll hear from us at this address 👆🏽</em>
+            <em>You&apos;ll hear from us at this address 👆🏽</em>
             <Field
               name="howYouFoundOutAboutUs"
               options={[

--- a/apps/web/app/routes/examples/forms/hidden-field.tsx
+++ b/apps/web/app/routes/examples/forms/hidden-field.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/labels-and-options.tsx
+++ b/apps/web/app/routes/examples/forms/labels-and-options.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/forms/use-fetcher.tsx
+++ b/apps/web/app/routes/examples/forms/use-fetcher.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/modes/on-blur.tsx
+++ b/apps/web/app/routes/examples/modes/on-blur.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/modes/on-change.tsx
+++ b/apps/web/app/routes/examples/modes/on-change.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/modes/on-submit.tsx
+++ b/apps/web/app/routes/examples/modes/on-submit.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/render-field/error-indicator.tsx
+++ b/apps/web/app/routes/examples/render-field/error-indicator.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/render-field/inline-checkboxes.tsx
+++ b/apps/web/app/routes/examples/render-field/inline-checkboxes.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/render-field/required-indicator.tsx
+++ b/apps/web/app/routes/examples/render-field/required-indicator.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/schemas/async-validation.tsx
+++ b/apps/web/app/routes/examples/schemas/async-validation.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/schemas/booleans.tsx
+++ b/apps/web/app/routes/examples/schemas/booleans.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/schemas/dates.tsx
+++ b/apps/web/app/routes/examples/schemas/dates.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/schemas/enums.tsx
+++ b/apps/web/app/routes/examples/schemas/enums.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/schemas/numbers.tsx
+++ b/apps/web/app/routes/examples/schemas/numbers.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'

--- a/apps/web/app/routes/examples/schemas/strings.tsx
+++ b/apps/web/app/routes/examples/schemas/strings.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
 import Form from '~/ui/form'
@@ -14,7 +18,7 @@ const description =
 export const meta: MetaFunction = () => metaTags({ title, description })
 
 const code = `const schema = z.object({
-  nonEmpty: z.string().nonempty(),
+  nonEmpty: z.string().min(1),
   optional: z.string().optional(),
   nullable: z.string().nullable(),
   default: z.string().default('Foo Bar'),
@@ -25,7 +29,7 @@ const code = `const schema = z.object({
   phoneNumber: z
     .string()
     .regex(
-      /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im,
+      /^[+]?[(]?[0-9]{3}[)]?[-\s.]?[0-9]{3}[-\s.]?[0-9]{4,6}$/im,
       'Invalid phone number',
     ),
 })
@@ -38,7 +42,7 @@ export const action: ActionFunction = async ({ request }) =>
 export default () => <Form schema={schema} />`
 
 const schema = z.object({
-  nonEmpty: z.string().nonempty(),
+  nonEmpty: z.string().min(1),
   optional: z.string().optional(),
   nullable: z.string().nullable(),
   default: z.string().default('Foo Bar'),
@@ -49,7 +53,7 @@ const schema = z.object({
   phoneNumber: z
     .string()
     .regex(
-      /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im,
+      /^[+]?[(]?[0-9]{3}[)]?[-\s.]?[0-9]{3}[-\s.]?[0-9]{4,6}$/im,
       'Invalid phone number',
     ),
 })

--- a/apps/web/app/routes/get-started.tsx
+++ b/apps/web/app/routes/get-started.tsx
@@ -160,9 +160,9 @@ export default function Component() {
       <Pre>npm install remix-forms</Pre>
       <SubHeading>Basic styles</SubHeading>
       <p>
-        Remix Forms doesn't ship any styles, so you need to configure basic
-        styles for your forms. Let's create a custom <em>Form</em> component for
-        your project:
+        Remix Forms doesn&apos;t ship any styles, so you need to configure basic
+        styles for your forms. Let&apos;s create a custom <em>Form</em>{' '}
+        component for your project:
       </p>
       <Code>{formCode}</Code>
       <div className="flex flex-col space-y-2">
@@ -176,11 +176,11 @@ export default function Component() {
         </p>
         <p>
           With your custom <em>Form</em> in place, now you can use it instead of
-          Remix Forms' for all your forms.
+          Remix Forms&apos; for all your forms.
         </p>
         <p>
-          PS: you don't need to customize everything. We'll use standard html
-          tags if you don't.
+          PS: you don&apos;t need to customize everything. We&apos;ll use
+          standard html tags if you don&apos;t.
         </p>
       </div>
       <SubHeading>Write your schema</SubHeading>
@@ -196,39 +196,39 @@ export default function Component() {
         <ExternalLink href="https://github.com/SeasonedSoftware/remix-domains">
           Remix Domains
         </ExternalLink>
-        ' <em>makeDomainFunction</em>. It's a function that receives the values
-        from the form and performs the necessary mutations, such as storing data
-        on a database.
+        &apos; <em>makeDomainFunction</em>. It&apos;s a function that receives
+        the values from the form and performs the necessary mutations, such as
+        storing data on a database.
       </p>
       <p>
-        Remix Domains will parse the request's <em>formData</em> and perform the
-        mutation only if everything is valid. If something goes bad, it will
-        return structured error messages for us.
+        Remix Domains will parse the request&apos;s <em>formData</em> and
+        perform the mutation only if everything is valid. If something goes bad,
+        it will return structured error messages for us.
       </p>
       <Code>{mutationCode}</Code>
       <SubHeading>Create your action</SubHeading>
       <p>
-        If the mutation is successful, Remix Forms' <em>formAction</em> will
-        redirect to <em>successPath</em>. If not, it will return <em>errors</em>{' '}
-        and <em>values</em> to pass to <em>Form</em>.
+        If the mutation is successful, Remix Forms&apos; <em>formAction</em>{' '}
+        will redirect to <em>successPath</em>. If not, it will return{' '}
+        <em>errors</em> and <em>values</em> to pass to <em>Form</em>.
       </p>
       <Code>{actionCode}</Code>
       <SubHeading>Create a basic form</SubHeading>
       <p>
-        If you don't want any custom UI in the form, you can render{' '}
+        If you don&apos;t want any custom UI in the form, you can render{' '}
         <em>Form</em> without <em>children</em> and it will generate all the
         inputs, labels, error messages and button for you.
       </p>
       <Code>{basicCode}</Code>
       <SubHeading>Custom Form, standard components</SubHeading>
       <p>
-        If you want a custom UI for your form, but don't need to customize the
-        rendering of fields, errors, and buttons, do it like this:
+        If you want a custom UI for your form, but don&apos;t need to customize
+        the rendering of fields, errors, and buttons, do it like this:
       </p>
       <Code>{customFormCode}</Code>
       <SubHeading>Custom Field, standard components</SubHeading>
       <p>
-        If you want a custom UI for a specific field, but don't need to
+        If you want a custom UI for a specific field, but don&apos;t need to
         customize the rendering of the label, input/select, and errors, do this:
       </p>
       <Code>{customFieldCode}</Code>
@@ -238,28 +238,30 @@ export default function Component() {
         <ExternalLink href="https://react-hook-form.com/">
           React Hook Form
         </ExternalLink>
-        's <em>register</em> (and everything else) through the <em>Form</em>'s{' '}
-        <em>children</em> and go nuts:
+        &apos;s <em>register</em> (and everything else) through the{' '}
+        <em>Form</em>
+        &apos;s <em>children</em> and go nuts:
       </p>
       <Code>{customInputCode}</Code>
-      <SubHeading>That's it!</SubHeading>
+      <SubHeading>That&apos;s it!</SubHeading>
       <div className="flex flex-col space-y-2">
         <p>
-          Now go play! Keep in mind that we're just getting started and the APIs
-          are unstable, so we appreciate your patience as we figure things out.
+          Now go play! Keep in mind that we&apos;re just getting started and the
+          APIs are unstable, so we appreciate your patience as we figure things
+          out.
         </p>
         <p>
           Also, please join{' '}
           <ExternalLink href="https://rmx.as/discord">
-            Remix's community on Discord
+            Remix&apos;s community on Discord
           </ExternalLink>
-          . We'll be there to provide you support on Remix Forms.
+          . We&apos;ll be there to provide you support on Remix Forms.
         </p>
       </div>
       <SubHeading>Appreciation</SubHeading>
       <p>
-        Remix Forms is a thin layer on top of giants. It wouldn't be possible
-        without{' '}
+        Remix Forms is a thin layer on top of giants. It wouldn&apos;t be
+        possible without{' '}
         <ExternalLink href="https://www.typescriptlang.org/">
           TypeScript
         </ExternalLink>

--- a/apps/web/app/routes/index.tsx
+++ b/apps/web/app/routes/index.tsx
@@ -1,5 +1,9 @@
 import hljs from 'highlight.js/lib/common'
-import type { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'

--- a/apps/web/app/routes/success.tsx
+++ b/apps/web/app/routes/success.tsx
@@ -7,7 +7,7 @@ export default function Component() {
     <div className="flex flex-col space-y-8 p-8 text-center sm:space-y-16 sm:p-16">
       <Heading>Success! 🎉</Heading>
       <SubHeading>
-        You've been magically redirected here from our successful form!
+        You&apos;ve been magically redirected here from our successful form!
       </SubHeading>
       <ButtonLink to={'/examples'}>
         Now check out our other examples 😄

--- a/apps/web/app/ui/base-button.tsx
+++ b/apps/web/app/ui/base-button.tsx
@@ -7,7 +7,7 @@ export default function BaseButton({
   return (
     <button
       className={cx(
-        'inline-flex items-center justify-center px-6 py-2 border border-transparent text-base font-medium rounded-md shadow-sm focus:outline-none ring-2 ring-offset-2 ring-transparent ring-offset-transparent disabled:bg-gray-400',
+        'inline-flex items-center justify-center rounded-md border border-transparent px-6 py-2 text-base font-medium shadow-sm ring-2 ring-transparent ring-offset-2 ring-offset-transparent focus:outline-none disabled:bg-gray-400',
         className,
       )}
       {...props}

--- a/apps/web/app/ui/button.tsx
+++ b/apps/web/app/ui/button.tsx
@@ -8,7 +8,7 @@ export default function Button({
   return (
     <BaseButton
       className={cx(
-        'text-white bg-pink-600 hover:bg-pink-700 focus:ring-pink-500 focus:ring-offset-white',
+        'bg-pink-600 text-white hover:bg-pink-700 focus:ring-pink-500 focus:ring-offset-white',
         className,
       )}
       {...props}

--- a/apps/web/app/ui/checkbox.tsx
+++ b/apps/web/app/ui/checkbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { cx } from '~/helpers'
 
 const Checkbox = React.forwardRef<
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
     className={cx(
       'h-4 w-4 rounded',
       className,
-      !className && 'border-gray-300 focus:ring-pink-500 text-pink-600',
+      !className && 'border-gray-300 text-pink-600 focus:ring-pink-500',
     )}
     {...props}
   />

--- a/apps/web/app/ui/external-link.tsx
+++ b/apps/web/app/ui/external-link.tsx
@@ -2,6 +2,7 @@ import { cx } from '~/helpers'
 
 export default function ExternalLink({
   className,
+  children,
   ...props
 }: JSX.IntrinsicElements['a']) {
   return (
@@ -10,6 +11,8 @@ export default function ExternalLink({
       rel="noopener noreferrer"
       {...props}
       className={cx('underline', className)}
-    />
+    >
+      {children}
+    </a>
   )
 }

--- a/apps/web/app/ui/feature.tsx
+++ b/apps/web/app/ui/feature.tsx
@@ -6,12 +6,12 @@ type Props = {
 
 export default function Feature({ icon: Icon, title, children }: Props) {
   return (
-    <div className="relative bg-white/20 w-full h-full p-4 rounded">
+    <div className="relative h-full w-full rounded bg-white/20 p-4">
       <dt>
-        <div className="absolute flex items-center justify-center h-12 w-12 rounded-md bg-pink-500 text-white">
+        <div className="absolute flex h-12 w-12 items-center justify-center rounded-md bg-pink-500 text-white">
           <Icon className="h-6 w-6" aria-hidden="true" />
         </div>
-        <h4 className="ml-16 text-lg leading-6 font-medium text-gray-300">
+        <h4 className="ml-16 text-lg font-medium leading-6 text-gray-300">
           {title}
         </h4>
       </dt>

--- a/apps/web/app/ui/form.tsx
+++ b/apps/web/app/ui/form.tsx
@@ -1,5 +1,6 @@
-import { Form as RemixForm, FormProps } from 'remix-forms'
-import { SomeZodObject } from 'zod'
+import type { FormProps } from 'remix-forms'
+import { Form as RemixForm } from 'remix-forms'
+import type { SomeZodObject } from 'zod'
 import Error from './error'
 import Errors from './errors'
 import Field from './field'

--- a/apps/web/app/ui/input.tsx
+++ b/apps/web/app/ui/input.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { cx } from '~/helpers'
 
 const Input = React.forwardRef<
@@ -9,9 +9,9 @@ const Input = React.forwardRef<
     ref={ref}
     type={type}
     className={cx(
-      'shadow-sm block w-full sm:text-sm rounded-md text-gray-800',
+      'block w-full rounded-md text-gray-800 shadow-sm sm:text-sm',
       className,
-      !className && 'border-gray-300 focus:ring-pink-500 focus:border-pink-500',
+      !className && 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
     )}
     {...props}
   />

--- a/apps/web/app/ui/nav-link.tsx
+++ b/apps/web/app/ui/nav-link.tsx
@@ -1,6 +1,6 @@
 import { NavLink as RemixNavLink } from '@remix-run/react'
+import type { RemixNavLinkProps } from '@remix-run/react/dist/components'
 import { cx } from '~/helpers'
-import { RemixNavLinkProps } from '@remix-run/react/components'
 
 export default function NavLink({ className, ...props }: RemixNavLinkProps) {
   return (
@@ -8,7 +8,7 @@ export default function NavLink({ className, ...props }: RemixNavLinkProps) {
       className={({ isActive }) =>
         cx(
           isActive ? 'text-white' : 'text-gray-100 hover:text-white',
-          'block px-3 py-2 rounded-md text-base font-medium',
+          'block rounded-md px-3 py-2 text-base font-medium',
           typeof className === 'function' ? className({ isActive }) : className,
         )
       }

--- a/apps/web/app/ui/secondary-button.tsx
+++ b/apps/web/app/ui/secondary-button.tsx
@@ -8,7 +8,7 @@ export default function SecondaryButton({
   return (
     <BaseButton
       className={cx(
-        'text-white border-2 border-gray-200 hover:border-white focus:ring-pink-500 focus:border-transparent focus:ring-offset-white',
+        'border-2 border-gray-200 text-white hover:border-white focus:border-transparent focus:ring-pink-500 focus:ring-offset-white',
         className,
       )}
       {...props}

--- a/apps/web/app/ui/select.tsx
+++ b/apps/web/app/ui/select.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { cx } from '~/helpers'
 
 const Select = React.forwardRef<
@@ -8,9 +8,9 @@ const Select = React.forwardRef<
   <select
     ref={ref}
     className={cx(
-      'block w-full pl-3 pr-10 py-2 text-base focus:outline-none sm:text-sm rounded-md text-gray-800',
+      'block w-full rounded-md py-2 pl-3 pr-10 text-base text-gray-800 focus:outline-none sm:text-sm',
       className,
-      !className && 'border-gray-300 focus:ring-pink-500 focus:border-pink-500',
+      !className && 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
     )}
     {...props}
   />

--- a/apps/web/app/ui/sidebar-layout.tsx
+++ b/apps/web/app/ui/sidebar-layout.tsx
@@ -1,9 +1,9 @@
+import * as React from 'react'
 import { Disclosure, Popover } from '@headlessui/react'
 import { cx } from '~/helpers'
 import { MenuAlt2Icon, MenuAlt3Icon, XIcon } from '@heroicons/react/outline'
-import { RemixNavLinkProps } from '@remix-run/react/components'
 import UINavLink from '~/ui/nav-link'
-import React from 'react'
+import type { RemixNavLinkProps } from '@remix-run/react/dist/components'
 
 type SidebarType = 'disclosure' | 'popover'
 
@@ -31,7 +31,10 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
             if (!React.isValidElement(child)) return child
 
             if (child.type === NavLink) {
-              return React.cloneElement(child, { type, close })
+              return React.cloneElement(child, {
+                type,
+                close,
+              } as React.HTMLAttributes<unknown>)
             }
 
             return child
@@ -107,16 +110,21 @@ type MapChildren = {
   close: Function
 }
 
-function mapChildren({ children, type, open, close }: MapChildren) {
+function mapChildren({ children, type, close }: MapChildren) {
   return React.Children.map(children, (child) => {
     if (!React.isValidElement(child)) return child
 
     if (child.type === Nav) {
-      return React.cloneElement(child, { type, close })
+      return React.cloneElement(child, {
+        type,
+        close,
+      } as React.HTMLAttributes<unknown>)
     }
 
     if (child.type === Content) {
-      return React.cloneElement(child, { type })
+      return React.cloneElement(child, {
+        type,
+      } as React.HTMLAttributes<unknown>)
     }
 
     return child

--- a/apps/web/app/ui/text-area.tsx
+++ b/apps/web/app/ui/text-area.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 const TextArea = React.forwardRef<
   HTMLTextAreaElement,
@@ -6,7 +6,7 @@ const TextArea = React.forwardRef<
 >((props, ref) => (
   <textarea
     ref={ref}
-    className="shadow-sm focus:ring-pink-500 focus:border-pink-500 block w-full sm:text-sm border-gray-300 rounded-md text-gray-800"
+    className="block w-full rounded-md border-gray-300 text-gray-800 shadow-sm focus:border-pink-500 focus:ring-pink-500 sm:text-sm"
     rows={5}
     {...props}
   />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "dev:css": "tailwindcss -w -i ./styles/app.css -o app/styles/app.css",
     "dev:server": "cross-env NODE_ENV=development netlify dev",
     "start": "cross-env NODE_ENV=production netlify dev",
+    "lint": "eslint *.ts*",
     "test": "playwright test",
     "pretest:ci": "npm run build",
     "test:ci": "playwright test"
@@ -40,7 +41,6 @@
   "devDependencies": {
     "@playwright/test": "^1.21.1",
     "@remix-run/dev": "^1.6.4",
-    "@remix-run/eslint-config": "^1.6.3",
     "@types/lodash": "^4.14.178",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",

--- a/apps/web/tests/examples/forms/custom-input.spec.ts
+++ b/apps/web/tests/examples/forms/custom-input.spec.ts
@@ -12,7 +12,7 @@ test('With JS enabled', async ({ example }) => {
   await expect(email.label).toHaveText('Email')
   await expect(email.label).toHaveId('label-for-email')
   await expect(email.input).toHaveAttribute('type', 'email')
-  await expect(email.input).toHaveClass('border-2 border-dashed rounded-md')
+  await expect(email.input).toHaveClass('rounded-md border-2 border-dashed')
   await expect(button).toBeEnabled()
 
   // Client-side validation

--- a/apps/web/tests/examples/forms/edit-values.spec.ts
+++ b/apps/web/tests/examples/forms/edit-values.spec.ts
@@ -6,7 +6,6 @@ test('With JS enabled', async ({ example }) => {
   const { firstName, email, button, page } = example
   const companySize = example.field('companySize')
   const howYouFoundOutAboutUs = example.field('howYouFoundOutAboutUs')
-  const subscribeToNewsletter = example.field('subscribeToNewsletter')
 
   await page.goto(route)
 

--- a/apps/web/tests/examples/render-field/error-indicator.spec.ts
+++ b/apps/web/tests/examples/render-field/error-indicator.spec.ts
@@ -32,7 +32,7 @@ test('With JS enabled', async ({ example }) => {
   )
 
   const errorClass =
-    'shadow-sm block w-full sm:text-sm rounded-md text-gray-800 border-red-600 focus:border-red-600 focus:ring-red-600'
+    'block w-full rounded-md text-gray-800 shadow-sm sm:text-sm border-red-600 focus:border-red-600 focus:ring-red-600'
 
   await expect(email.input).toHaveClass(errorClass)
   await expect(firstName.input).toHaveClass(errorClass)
@@ -53,7 +53,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(newsletter)
 
   const validClass =
-    'shadow-sm block w-full sm:text-sm rounded-md text-gray-800 border-gray-300 focus:ring-pink-500 focus:border-pink-500'
+    'block w-full rounded-md text-gray-800 shadow-sm sm:text-sm border-gray-300 focus:border-pink-500 focus:ring-pink-500'
 
   await expect(email.input).toHaveClass(validClass)
   await expect(firstName.input).toHaveClass(validClass)

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
       "devDependencies": {
         "@playwright/test": "^1.21.1",
         "@remix-run/dev": "^1.6.4",
-        "@remix-run/eslint-config": "^1.6.3",
         "@types/lodash": "^4.14.178",
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
@@ -504,43 +503,6 @@
         "node": ">=12"
       }
     },
-    "apps/web/node_modules/@remix-run/eslint-config": {
-      "version": "1.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.17.5",
-        "@babel/eslint-parser": "^7.17.0",
-        "@babel/preset-react": "^7.16.7",
-        "@rushstack/eslint-patch": "^1.1.0",
-        "@typescript-eslint/eslint-plugin": "^5.12.1",
-        "@typescript-eslint/parser": "^5.12.1",
-        "eslint-import-resolver-node": "0.3.6",
-        "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-plugin-import": "^2.25.4",
-        "eslint-plugin-jest": "^26.1.1",
-        "eslint-plugin-jest-dom": "^4.0.1",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-testing-library": "^5.0.5"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "typescript": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "apps/web/node_modules/@remix-run/node": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.6.4.tgz",
@@ -913,7 +875,6 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
@@ -932,7 +893,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -940,7 +900,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
@@ -969,7 +928,6 @@
     },
     "node_modules/@babel/core/node_modules/@babel/code-frame": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
@@ -980,7 +938,6 @@
     },
     "node_modules/@babel/core/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -992,7 +949,6 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1000,7 +956,6 @@
     },
     "node_modules/@babel/eslint-parser": {
       "version": "7.18.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-scope": "^5.1.1",
@@ -1017,7 +972,6 @@
     },
     "node_modules/@babel/eslint-parser/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1025,7 +979,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.7",
@@ -1038,7 +991,6 @@
     },
     "node_modules/@babel/generator/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1050,7 +1002,6 @@
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -1063,7 +1014,6 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -1074,7 +1024,6 @@
     },
     "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1110,7 +1059,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.18.6",
@@ -1127,7 +1075,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1196,7 +1143,6 @@
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1227,7 +1173,6 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.18.6",
@@ -1239,7 +1184,6 @@
     },
     "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1251,7 +1195,6 @@
     },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -1262,7 +1205,6 @@
     },
     "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1297,7 +1239,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -1308,7 +1249,6 @@
     },
     "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1320,7 +1260,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.6",
@@ -1338,7 +1277,6 @@
     },
     "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1373,7 +1311,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1437,7 +1374,6 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -1448,7 +1384,6 @@
     },
     "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1483,7 +1418,6 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -1494,7 +1428,6 @@
     },
     "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1513,7 +1446,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1547,7 +1479,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.18.6",
@@ -1560,7 +1491,6 @@
     },
     "node_modules/@babel/helpers/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -1641,7 +1571,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2015,7 +1944,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
       "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -2506,7 +2434,6 @@
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -2520,7 +2447,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -2538,7 +2464,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.18.6"
@@ -2552,7 +2477,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -2564,7 +2488,6 @@
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -2863,7 +2786,6 @@
     },
     "node_modules/@babel/preset-react": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
@@ -2937,7 +2859,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -2950,7 +2871,6 @@
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
@@ -2961,7 +2881,6 @@
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -2973,7 +2892,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -2993,7 +2911,6 @@
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
       "version": "7.18.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
@@ -3004,7 +2921,6 @@
     },
     "node_modules/@babel/traverse/node_modules/@babel/types": {
       "version": "7.18.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
@@ -3016,7 +2932,6 @@
     },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3125,7 +3040,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
@@ -3137,7 +3051,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.8",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3145,7 +3058,6 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3153,12 +3065,10 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.14",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -3174,13 +3084,6 @@
       },
       "engines": {
         "node": ">=8.3.0"
-      }
-    },
-    "node_modules/@next/eslint-plugin-next": {
-      "version": "12.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "7.1.7"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3633,7 +3536,6 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "8.14.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -3651,7 +3553,6 @@
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
       "version": "5.0.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=6.0"
@@ -3667,7 +3568,6 @@
     },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/cacheable-request": {
@@ -3753,7 +3653,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -3863,7 +3762,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.30.5",
@@ -3895,7 +3793,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3943,7 +3840,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.30.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "5.30.5",
@@ -4004,7 +3900,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.30.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -4027,7 +3922,6 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
@@ -4705,7 +4599,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.21.1",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5007,7 +4900,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001363",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5495,7 +5387,6 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.1"
@@ -5503,7 +5394,6 @@
     },
     "node_modules/convert-source-map/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -5880,7 +5770,6 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.14",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dotenv": {
@@ -5935,7 +5824,6 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.179",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6673,7 +6561,6 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6751,88 +6638,6 @@
     "node_modules/eslint-config-custom": {
       "resolved": "packages/eslint-config-custom",
       "link": true
-    },
-    "node_modules/eslint-config-next": {
-      "version": "12.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@next/eslint-plugin-next": "12.2.0",
-        "@rushstack/eslint-patch": "^1.1.3",
-        "@typescript-eslint/parser": "^5.21.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-import-resolver-typescript": "^2.7.1",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.29.4",
-        "eslint-plugin-react-hooks": "^4.5.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0",
-        "typescript": ">=3.3.1"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/doctrine": {
-      "version": "2.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
-      "version": "7.30.1",
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
-        "doctrine": "^2.1.0",
-        "estraverse": "^5.3.0",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
-        "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/resolve": {
-      "version": "2.0.0-next.4",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/eslint-config-prettier": {
       "version": "8.5.0",
@@ -6915,7 +6720,6 @@
     },
     "node_modules/eslint-plugin-es": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-utils": "^2.0.0",
@@ -6979,7 +6783,6 @@
     },
     "node_modules/eslint-plugin-jest": {
       "version": "26.5.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -7002,7 +6805,6 @@
     },
     "node_modules/eslint-plugin-jest-dom": {
       "version": "4.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.16.3",
@@ -7052,7 +6854,6 @@
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-es": "^3.0.0",
@@ -7071,7 +6872,6 @@
     },
     "node_modules/eslint-plugin-node/node_modules/ignore": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7079,7 +6879,6 @@
     },
     "node_modules/eslint-plugin-node/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7155,7 +6954,6 @@
     },
     "node_modules/eslint-plugin-testing-library": {
       "version": "5.5.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^5.13.0"
@@ -8005,7 +7803,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -9263,7 +9060,6 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -9297,7 +9093,6 @@
     },
     "node_modules/json5": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -9535,7 +9330,6 @@
     },
     "node_modules/lz-string": {
       "version": "1.4.4",
-      "dev": true,
       "license": "WTFPL",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -33668,7 +33462,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
@@ -34656,7 +34449,6 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -34669,7 +34461,6 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -34870,7 +34661,6 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-router": {
@@ -35317,7 +35107,6 @@
     },
     "node_modules/requireindex": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.5"
@@ -36661,7 +36450,6 @@
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -37785,7 +37573,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.4",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -38686,13 +38473,250 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "eslint-config-next": "^12.0.8",
+        "@remix-run/eslint-config": "^1.6.5",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-react": "7.28.0"
       }
     },
+    "packages/eslint-config-custom/node_modules/@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "peer": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/@remix-run/eslint-config": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.6.5.tgz",
+      "integrity": "sha512-l1HQUcbF+RvN3CK7haf1FgHIIoM8l13/RyHsTsjjQA6jv4/e0xMykfzfwRsrJL49O8cyZ6H09lRvvG5beR6Owg==",
+      "dependencies": {
+        "@babel/core": "^7.18.6",
+        "@babel/eslint-parser": "^7.18.2",
+        "@babel/preset-react": "^7.18.6",
+        "@rushstack/eslint-patch": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^5.12.1",
+        "@typescript-eslint/parser": "^5.12.1",
+        "eslint-import-resolver-node": "0.3.6",
+        "eslint-import-resolver-typescript": "^2.5.0",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-jest": "^26.1.1",
+        "eslint-plugin-jest-dom": "^4.0.1",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-testing-library": "^5.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "typescript": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/eslint-config-custom/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "peer": true
+    },
+    "packages/eslint-config-custom/node_modules/eslint": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+      "peer": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.2",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/eslint-config-custom/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "packages/remix-forms": {
-      "version": "0.17.3",
+      "version": "0.17.4-rc.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^2.8.8",
@@ -38728,7 +38752,6 @@
   "dependencies": {
     "@ampproject/remapping": {
       "version": "2.2.0",
-      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -38741,12 +38764,10 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.18.6",
-      "dev": true
+      "version": "7.18.6"
     },
     "@babel/core": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -38767,28 +38788,24 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.18.6",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.18.6"
           }
         },
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "dev": true
+          "version": "6.3.0"
         }
       }
     },
     "@babel/eslint-parser": {
       "version": "7.18.2",
-      "dev": true,
       "requires": {
         "eslint-scope": "^5.1.1",
         "eslint-visitor-keys": "^2.1.0",
@@ -38796,14 +38813,12 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "dev": true
+          "version": "6.3.0"
         }
       }
     },
     "@babel/generator": {
       "version": "7.18.7",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -38812,7 +38827,6 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -38820,7 +38834,6 @@
         },
         "@jridgewell/gen-mapping": {
           "version": "0.3.2",
-          "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -38831,14 +38844,12 @@
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -38866,7 +38877,6 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.18.6",
         "@babel/helper-validator-option": "^7.18.6",
@@ -38875,8 +38885,7 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "dev": true
+          "version": "6.3.0"
         }
       }
     },
@@ -38922,8 +38931,7 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.18.6",
-      "dev": true
+      "version": "7.18.6"
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.18.6",
@@ -38944,7 +38952,6 @@
     },
     "@babel/helper-function-name": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.18.6",
         "@babel/types": "^7.18.6"
@@ -38952,7 +38959,6 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -38962,14 +38968,12 @@
     },
     "@babel/helper-hoist-variables": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -38996,14 +39000,12 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -39013,7 +39015,6 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -39027,7 +39028,6 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -39053,8 +39053,7 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "dev": true
+      "version": "7.18.6"
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.18.6",
@@ -39099,14 +39098,12 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -39133,14 +39130,12 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       },
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -39152,8 +39147,7 @@
       "version": "7.18.6"
     },
     "@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "dev": true
+      "version": "7.18.6"
     },
     "@babel/helper-wrap-function": {
       "version": "7.18.6",
@@ -39177,7 +39171,6 @@
     },
     "@babel/helpers": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.18.6",
         "@babel/traverse": "^7.18.6",
@@ -39186,7 +39179,6 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -39240,8 +39232,7 @@
       }
     },
     "@babel/parser": {
-      "version": "7.18.6",
-      "dev": true
+      "version": "7.18.6"
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.18.6",
@@ -39448,7 +39439,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
       "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -39718,14 +39708,12 @@
     },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-jsx": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -39736,7 +39724,6 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -39746,14 +39733,12 @@
     },
     "@babel/plugin-transform-react-jsx-development": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -39951,7 +39936,6 @@
     },
     "@babel/preset-react": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/helper-validator-option": "^7.18.6",
@@ -39996,7 +39980,6 @@
     },
     "@babel/template": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.6",
@@ -40005,14 +39988,12 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.18.6",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.18.6"
           }
         },
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
@@ -40022,7 +40003,6 @@
     },
     "@babel/traverse": {
       "version": "7.18.6",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.6",
@@ -40038,22 +40018,19 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.18.6",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.18.6"
           }
         },
         "@babel/types": {
           "version": "7.18.7",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.18.6",
             "to-fast-properties": "^2.0.0"
           }
         },
         "globals": {
-          "version": "11.12.0",
-          "dev": true
+          "version": "11.12.0"
         }
       }
     },
@@ -40124,27 +40101,22 @@
     },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
-      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.8",
-      "dev": true
+      "version": "3.0.8"
     },
     "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "dev": true
+      "version": "1.4.14"
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.14",
-      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -40156,12 +40128,6 @@
       "integrity": "sha512-7fnJv3vr8uyyyOYPChwoec6MjzsCw1CoRUO2DhQ1BD6bOyJRlD4DUaOOGlMILB2LCT8P24p5LexEGx8AJb7xdA==",
       "requires": {
         "is-promise": "^4.0.0"
-      }
-    },
-    "@next/eslint-plugin-next": {
-      "version": "12.2.0",
-      "requires": {
-        "glob": "7.1.7"
       }
     },
     "@nodelib/fs.scandir": {
@@ -40463,7 +40429,6 @@
     },
     "@testing-library/dom": {
       "version": "8.14.0",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -40476,8 +40441,7 @@
       },
       "dependencies": {
         "aria-query": {
-          "version": "5.0.0",
-          "dev": true
+          "version": "5.0.0"
         }
       }
     },
@@ -40489,8 +40453,7 @@
       }
     },
     "@types/aria-query": {
-      "version": "4.2.2",
-      "dev": true
+      "version": "4.2.2"
     },
     "@types/cacheable-request": {
       "version": "6.0.2",
@@ -40562,8 +40525,7 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true
+      "version": "7.0.11"
     },
     "@types/json5": {
       "version": "0.0.29"
@@ -40654,7 +40616,6 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.30.5",
-      "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.30.5",
         "@typescript-eslint/type-utils": "5.30.5",
@@ -40668,8 +40629,7 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.2.0",
-          "dev": true
+          "version": "5.2.0"
         }
       }
     },
@@ -40691,7 +40651,6 @@
     },
     "@typescript-eslint/type-utils": {
       "version": "5.30.5",
-      "dev": true,
       "requires": {
         "@typescript-eslint/utils": "5.30.5",
         "debug": "^4.3.4",
@@ -40715,7 +40674,6 @@
     },
     "@typescript-eslint/utils": {
       "version": "5.30.5",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@typescript-eslint/scope-manager": "5.30.5",
@@ -40727,7 +40685,6 @@
       "dependencies": {
         "eslint-utils": {
           "version": "3.0.0",
-          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
           }
@@ -41131,7 +41088,6 @@
     },
     "browserslist": {
       "version": "4.21.1",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001359",
         "electron-to-chromium": "^1.4.172",
@@ -41304,8 +41260,7 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001363",
-      "dev": true
+      "version": "1.0.30001363"
     },
     "chai": {
       "version": "4.3.6",
@@ -41612,14 +41567,12 @@
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
+          "version": "5.1.2"
         }
       }
     },
@@ -41830,8 +41783,7 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.14",
-      "dev": true
+      "version": "0.5.14"
     },
     "dotenv": {
       "version": "16.0.1",
@@ -41877,8 +41829,7 @@
       "version": "1.1.1"
     },
     "electron-to-chromium": {
-      "version": "1.4.179",
-      "dev": true
+      "version": "1.4.179"
     },
     "emoji-regex": {
       "version": "9.2.2"
@@ -42239,8 +42190,7 @@
       "optional": true
     },
     "escalade": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "escape-html": {
       "version": "1.0.3"
@@ -42296,60 +42246,186 @@
     "eslint-config-custom": {
       "version": "file:packages/eslint-config-custom",
       "requires": {
-        "eslint-config-next": "^12.0.8",
+        "@remix-run/eslint-config": "^1.6.5",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-react": "7.28.0"
-      }
-    },
-    "eslint-config-next": {
-      "version": "12.2.0",
-      "requires": {
-        "@next/eslint-plugin-next": "12.2.0",
-        "@rushstack/eslint-patch": "^1.1.3",
-        "@typescript-eslint/parser": "^5.21.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-import-resolver-typescript": "^2.7.1",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.29.4",
-        "eslint-plugin-react-hooks": "^4.5.0"
       },
       "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
+        "@eslint/eslintrc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+          "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+          "peer": true,
           "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "eslint-plugin-react": {
-          "version": "7.30.1",
-          "requires": {
-            "array-includes": "^3.1.5",
-            "array.prototype.flatmap": "^1.3.0",
-            "doctrine": "^2.1.0",
-            "estraverse": "^5.3.0",
-            "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+            "ajv": "^6.12.4",
+            "debug": "^4.3.2",
+            "espree": "^9.3.2",
+            "globals": "^13.15.0",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^4.1.0",
             "minimatch": "^3.1.2",
-            "object.entries": "^1.1.5",
-            "object.fromentries": "^2.0.5",
-            "object.hasown": "^1.1.1",
-            "object.values": "^1.1.5",
-            "prop-types": "^15.8.1",
-            "resolve": "^2.0.0-next.3",
-            "semver": "^6.3.0",
-            "string.prototype.matchall": "^4.0.7"
+            "strip-json-comments": "^3.1.1"
           }
         },
-        "resolve": {
-          "version": "2.0.0-next.4",
+        "@humanwhocodes/config-array": {
+          "version": "0.9.5",
+          "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+          "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+          "peer": true,
           "requires": {
-            "is-core-module": "^2.9.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
+            "@humanwhocodes/object-schema": "^1.2.1",
+            "debug": "^4.1.1",
+            "minimatch": "^3.0.4"
           }
         },
-        "semver": {
-          "version": "6.3.0"
+        "@remix-run/eslint-config": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.6.5.tgz",
+          "integrity": "sha512-l1HQUcbF+RvN3CK7haf1FgHIIoM8l13/RyHsTsjjQA6jv4/e0xMykfzfwRsrJL49O8cyZ6H09lRvvG5beR6Owg==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/eslint-parser": "^7.18.2",
+            "@babel/preset-react": "^7.18.6",
+            "@rushstack/eslint-patch": "^1.1.0",
+            "@typescript-eslint/eslint-plugin": "^5.12.1",
+            "@typescript-eslint/parser": "^5.12.1",
+            "eslint-import-resolver-node": "0.3.6",
+            "eslint-import-resolver-typescript": "^2.5.0",
+            "eslint-plugin-import": "^2.25.4",
+            "eslint-plugin-jest": "^26.1.1",
+            "eslint-plugin-jest-dom": "^4.0.1",
+            "eslint-plugin-jsx-a11y": "^6.5.1",
+            "eslint-plugin-node": "^11.1.0",
+            "eslint-plugin-react": "^7.28.0",
+            "eslint-plugin-react-hooks": "^4.3.0",
+            "eslint-plugin-testing-library": "^5.0.5"
+          }
+        },
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "peer": true
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "peer": true
+        },
+        "eslint": {
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+          "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+          "peer": true,
+          "requires": {
+            "@eslint/eslintrc": "^1.3.0",
+            "@humanwhocodes/config-array": "^0.9.2",
+            "ajv": "^6.10.0",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
+            "debug": "^4.3.2",
+            "doctrine": "^3.0.0",
+            "escape-string-regexp": "^4.0.0",
+            "eslint-scope": "^7.1.1",
+            "eslint-utils": "^3.0.0",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.2",
+            "esquery": "^1.4.0",
+            "esutils": "^2.0.2",
+            "fast-deep-equal": "^3.1.3",
+            "file-entry-cache": "^6.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^6.0.1",
+            "globals": "^13.15.0",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^4.1.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.4.1",
+            "lodash.merge": "^4.6.2",
+            "minimatch": "^3.1.2",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.9.1",
+            "regexpp": "^3.2.0",
+            "strip-ansi": "^6.0.1",
+            "strip-json-comments": "^3.1.0",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+              "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+              "peer": true
+            }
+          }
+        },
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "peer": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "peer": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "espree": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+          "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+          "peer": true,
+          "requires": {
+            "acorn": "^8.7.1",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.3.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+              "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+              "peer": true
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "peer": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "peer": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "peer": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         }
       }
     },
@@ -42412,7 +42488,6 @@
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
-      "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
@@ -42455,14 +42530,12 @@
     },
     "eslint-plugin-jest": {
       "version": "26.5.3",
-      "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-jest-dom": {
       "version": "4.0.2",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.3",
         "@testing-library/dom": "^8.11.1",
@@ -42494,7 +42567,6 @@
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
-      "dev": true,
       "requires": {
         "eslint-plugin-es": "^3.0.0",
         "eslint-utils": "^2.0.0",
@@ -42505,12 +42577,10 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.2.0",
-          "dev": true
+          "version": "5.2.0"
         },
         "semver": {
-          "version": "6.3.0",
-          "dev": true
+          "version": "6.3.0"
         }
       }
     },
@@ -42558,7 +42628,6 @@
     },
     "eslint-plugin-testing-library": {
       "version": "5.5.1",
-      "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.13.0"
       }
@@ -43111,8 +43180,7 @@
       "version": "1.2.3"
     },
     "gensync": {
-      "version": "1.0.0-beta.2",
-      "dev": true
+      "version": "1.0.0-beta.2"
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -43867,8 +43935,7 @@
       }
     },
     "jsesc": {
-      "version": "2.5.2",
-      "dev": true
+      "version": "2.5.2"
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -43890,8 +43957,7 @@
       "version": "1.0.1"
     },
     "json5": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -44042,8 +44108,7 @@
       }
     },
     "lz-string": {
-      "version": "1.4.4",
-      "dev": true
+      "version": "1.4.4"
     },
     "magic-string": {
       "version": "0.25.9",
@@ -61839,8 +61904,7 @@
       }
     },
     "node-releases": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -62429,7 +62493,6 @@
     },
     "pretty-format": {
       "version": "27.5.1",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -62437,8 +62500,7 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "5.2.0",
-          "dev": true
+          "version": "5.2.0"
         }
       }
     },
@@ -62551,8 +62613,7 @@
       "requires": {}
     },
     "react-is": {
-      "version": "17.0.2",
-      "dev": true
+      "version": "17.0.2"
     },
     "react-router": {
       "version": "6.3.0",
@@ -62851,7 +62912,6 @@
         "@netlify/functions": "^1.0.0",
         "@playwright/test": "^1.21.1",
         "@remix-run/dev": "^1.6.4",
-        "@remix-run/eslint-config": "^1.6.3",
         "@remix-run/netlify": "^1.6.4",
         "@remix-run/node": "^1.6.4",
         "@remix-run/react": "^1.6.4",
@@ -63124,28 +63184,6 @@
             }
           }
         },
-        "@remix-run/eslint-config": {
-          "version": "1.6.3",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.17.5",
-            "@babel/eslint-parser": "^7.17.0",
-            "@babel/preset-react": "^7.16.7",
-            "@rushstack/eslint-patch": "^1.1.0",
-            "@typescript-eslint/eslint-plugin": "^5.12.1",
-            "@typescript-eslint/parser": "^5.12.1",
-            "eslint-import-resolver-node": "0.3.6",
-            "eslint-import-resolver-typescript": "^2.5.0",
-            "eslint-plugin-import": "^2.25.4",
-            "eslint-plugin-jest": "^26.1.1",
-            "eslint-plugin-jest-dom": "^4.0.1",
-            "eslint-plugin-jsx-a11y": "^6.5.1",
-            "eslint-plugin-node": "^11.1.0",
-            "eslint-plugin-react": "^7.28.0",
-            "eslint-plugin-react-hooks": "^4.3.0",
-            "eslint-plugin-testing-library": "^5.0.5"
-          }
-        },
         "@remix-run/node": {
           "version": "1.6.4",
           "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.6.4.tgz",
@@ -63414,8 +63452,7 @@
       "version": "2.0.2"
     },
     "requireindex": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "resolve": {
       "version": "1.22.1",
@@ -64337,8 +64374,7 @@
       }
     },
     "to-fast-properties": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -64970,7 +65006,6 @@
     },
     "update-browserslist-db": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -1,7 +1,11 @@
 module.exports = {
-  extends: ["next", "prettier"],
+  extends: [
+    '@remix-run/eslint-config',
+    '@remix-run/eslint-config/node',
+    'prettier',
+  ],
   rules: {
-    "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
+    'react/jsx-key': 'off',
+    'react/display-name': 'off',
   },
-};
+}

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-next": "^12.0.8",
+    "@remix-run/eslint-config": "^1.6.5",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.28.0"
   },

--- a/packages/remix-forms/src/Form.tsx
+++ b/packages/remix-forms/src/Form.tsx
@@ -1,31 +1,32 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import * as React from 'react'
+import type { FormProps as RemixFormProps, FormMethod } from '@remix-run/react'
 import {
   Form as RemixForm,
-  FormProps as RemixFormProps,
-  FormMethod,
   useTransition,
   useSubmit,
   useActionData,
 } from '@remix-run/react'
-import { SomeZodObject, z, ZodTypeAny } from 'zod'
-import {
-  useForm,
+import type { SomeZodObject, z, ZodTypeAny } from 'zod'
+import type {
   UseFormReturn,
   FieldError,
   Path,
   ValidationMode,
 } from 'react-hook-form'
+import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { FormErrors, FormValues } from './formAction.server'
-import createField, { FieldProps, FieldType } from './createField'
-import mapChildren from './mapChildren'
-import defaultRenderField from './defaultRenderField'
-import { Fetcher } from '@remix-run/react'
-import inferLabel from './inferLabel'
-import { shapeInfo, ZodTypeName } from './shapeInfo'
-import { Transition } from '@remix-run/react/dist/transition'
+import type { FormErrors, FormValues } from './formAction.server'
+import type { FieldProps, FieldType } from './createField'
+import { createField } from './createField'
+import { mapChildren } from './mapChildren'
+import { defaultRenderField } from './defaultRenderField'
+import type { Fetcher } from '@remix-run/react'
+import { inferLabel } from './inferLabel'
+import type { ZodTypeName } from './shapeInfo'
+import { shapeInfo } from './shapeInfo'
+import type { Transition } from '@remix-run/react/dist/transition'
 
-export type Field<SchemaType> = {
+type Field<SchemaType> = {
   shape: ZodTypeAny
   fieldType: FieldType
   name: keyof SchemaType
@@ -43,17 +44,15 @@ export type Field<SchemaType> = {
 type FieldComponent<Schema extends SomeZodObject> =
   React.ForwardRefExoticComponent<FieldProps<Schema> & React.RefAttributes<any>>
 
-export type RenderFieldProps<Schema extends SomeZodObject> = Field<
-  z.infer<Schema>
-> & {
+type RenderFieldProps<Schema extends SomeZodObject> = Field<z.infer<Schema>> & {
   Field: FieldComponent<Schema>
 }
 
-export type RenderField<Schema extends SomeZodObject> = (
+type RenderField<Schema extends SomeZodObject> = (
   props: RenderFieldProps<Schema>,
 ) => JSX.Element
 
-export type Option = { name: string } & Required<
+type Option = { name: string } & Required<
   Pick<React.OptionHTMLAttributes<HTMLOptionElement>, 'value'>
 >
 
@@ -85,7 +84,7 @@ type OnTransition<Schema extends SomeZodObject> = (
   } & UseFormReturn<z.infer<Schema>, any>,
 ) => void
 
-export type FormProps<Schema extends SomeZodObject> = {
+type FormProps<Schema extends SomeZodObject> = {
   component?: React.ForwardRefExoticComponent<AllRemixFormProps>
   fetcher?: Fetcher<any> & {
     Form: ReturnType<any>
@@ -158,7 +157,7 @@ const fieldTypes: Record<ZodTypeName, FieldType> = {
   ZodEnum: 'string',
 }
 
-export function Form<Schema extends SomeZodObject>({
+function Form<Schema extends SomeZodObject>({
   component = RemixForm,
   fetcher,
   mode = 'onSubmit',
@@ -214,9 +213,9 @@ export function Form<Schema extends SomeZodObject>({
 
   const { formState } = form
   const { errors: formErrors, isValid } = formState
-  const [disabled, setDisabled] = useState(false)
+  const [disabled, setDisabled] = React.useState(false)
 
-  useEffect(() => {
+  React.useEffect(() => {
     const shouldDisable =
       mode === 'onChange' || mode === 'all'
         ? transition.state === 'submitting' || !isValid
@@ -226,7 +225,7 @@ export function Form<Schema extends SomeZodObject>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transition.state, formState])
 
-  useEffect(() => {
+  React.useEffect(() => {
     onTransition && onTransition({ transition, ...form })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transition.state])
@@ -235,7 +234,7 @@ export function Form<Schema extends SomeZodObject>({
     form.handleSubmit(() => submit(event.target))(event)
   }
 
-  const Field = useMemo(
+  const Field = React.useMemo(
     () =>
       createField<Schema>({
         register: form.register,
@@ -263,7 +262,7 @@ export function Form<Schema extends SomeZodObject>({
     ],
   )
 
-  useEffect(() => {
+  React.useEffect(() => {
     for (const stringKey in schema.shape) {
       const key = stringKey as keyof SchemaType
       if (errors && errors[key]?.length) {
@@ -423,3 +422,6 @@ export function Form<Schema extends SomeZodObject>({
     </Component>
   )
 }
+
+export type { Field, RenderFieldProps, RenderField, Option, FormProps }
+export { Form }

--- a/packages/remix-forms/src/coercions.ts
+++ b/packages/remix-forms/src/coercions.ts
@@ -1,4 +1,4 @@
-import { ZodTypeAny } from 'zod'
+import type { ZodTypeAny } from 'zod'
 import { shapeInfo } from './shapeInfo'
 
 function makeCoercion<T>(

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo } from 'react'
-import { SomeZodObject, z } from 'zod'
-import { UseFormRegister } from 'react-hook-form'
-import { FormProps } from '.'
-import { Field } from './Form'
-import mapChildren from './mapChildren'
+import * as React from 'react'
+import type { SomeZodObject, z } from 'zod'
+import type { UseFormRegister } from 'react-hook-form'
+import type { FormProps } from '.'
+import type { Field } from './Form'
+import { mapChildren } from './mapChildren'
 import { coerceValue } from './coercions'
-import createSmartInput, { SmartInputProps } from './createSmartInput'
+import type { SmartInputProps } from './createSmartInput'
+import { createSmartInput } from './createSmartInput'
 
 type Children<Schema extends SomeZodObject> = (
   helpers: FieldBaseProps<Schema> & {
@@ -42,7 +43,7 @@ type Children<Schema extends SomeZodObject> = (
   },
 ) => React.ReactNode
 
-export type FieldType = 'string' | 'boolean' | 'number' | 'date'
+type FieldType = 'string' | 'boolean' | 'number' | 'date'
 
 type FieldBaseProps<Schema extends SomeZodObject> = Omit<
   Partial<Field<z.infer<Schema>>>,
@@ -53,7 +54,7 @@ type FieldBaseProps<Schema extends SomeZodObject> = Omit<
   children?: Children<Schema>
 }
 
-export type FieldProps<Schema extends SomeZodObject> = FieldBaseProps<Schema> &
+type FieldProps<Schema extends SomeZodObject> = FieldBaseProps<Schema> &
   Omit<JSX.IntrinsicElements['div'], 'children'>
 
 const types: Record<FieldType, React.HTMLInputTypeAttribute> = {
@@ -71,7 +72,7 @@ function parseDate(value?: Date | string) {
   return date
 }
 
-export default function createField<Schema extends SomeZodObject>({
+function createField<Schema extends SomeZodObject>({
   register,
   fieldComponent: Field = 'div',
   labelComponent: Label = 'label',
@@ -147,7 +148,7 @@ export default function createField<Schema extends SomeZodObject>({
         'aria-required': required,
       }
 
-      const SmartInput = useMemo(
+      const SmartInput = React.useMemo(
         () =>
           createSmartInput({
             inputComponent: Input,
@@ -155,6 +156,7 @@ export default function createField<Schema extends SomeZodObject>({
             selectComponent: Select,
             checkboxComponent: Checkbox,
           }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [Input, Multiline, Select, Checkbox],
       )
 
@@ -322,3 +324,6 @@ export default function createField<Schema extends SomeZodObject>({
     },
   )
 }
+
+export type { FieldType, FieldProps }
+export { createField }

--- a/packages/remix-forms/src/createSmartInput.tsx
+++ b/packages/remix-forms/src/createSmartInput.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import { UseFormRegisterReturn } from 'react-hook-form'
-import { SomeZodObject } from 'zod'
-import { FieldType } from './createField'
-import { FormProps } from './Form'
+import * as React from 'react'
+import type { UseFormRegisterReturn } from 'react-hook-form'
+import type { SomeZodObject } from 'zod'
+import type { FieldType } from './createField'
+import type { FormProps } from './Form'
 
-export type SmartInputProps = {
+type SmartInputProps = {
   fieldType?: FieldType
   type?: React.HTMLInputTypeAttribute
   value?: any
@@ -17,7 +17,7 @@ export type SmartInputProps = {
   a11yProps?: Record<`aria-${string}`, string | boolean | undefined>
 }
 
-export default function createSmartInput<Schema extends SomeZodObject>({
+function createSmartInput<Schema extends SomeZodObject>({
   inputComponent: Input = 'input',
   multilineComponent: Multiline = 'textarea',
   selectComponent: Select = 'select',
@@ -109,3 +109,6 @@ export default function createSmartInput<Schema extends SomeZodObject>({
     )
   }
 }
+
+export type { SmartInputProps }
+export { createSmartInput }

--- a/packages/remix-forms/src/defaultRenderField.tsx
+++ b/packages/remix-forms/src/defaultRenderField.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
-import { SomeZodObject } from 'zod'
-import { RenderFieldProps } from './Form'
+import type { SomeZodObject } from 'zod'
+import type { RenderFieldProps } from './Form'
 
-export default function defaultRenderField<Schema extends SomeZodObject>({
+function defaultRenderField<Schema extends SomeZodObject>({
   Field,
   name,
   ...props
 }: RenderFieldProps<Schema>) {
   return <Field key={String(name)} name={name} {...props} />
 }
+
+export { defaultRenderField }

--- a/packages/remix-forms/src/formAction.server.ts
+++ b/packages/remix-forms/src/formAction.server.ts
@@ -1,42 +1,40 @@
 import { json, redirect } from '@remix-run/server-runtime'
-import { DomainFunction, errorMessagesForSchema } from 'remix-domains'
-import { SomeZodObject, z } from 'zod'
-import getFormValues from './getFormValues'
+import type { DomainFunction } from 'remix-domains'
+import { errorMessagesForSchema } from 'remix-domains'
+import type { SomeZodObject, z } from 'zod'
+import { getFormValues } from './getFormValues'
 
 type FormActionFailure<SchemaType> = {
   errors: FormErrors<SchemaType>
   values: FormValues<SchemaType>
 }
 
-export type FormValues<SchemaType> = Partial<Record<keyof SchemaType, any>>
+type FormValues<SchemaType> = Partial<Record<keyof SchemaType, any>>
 
-export type FormErrors<SchemaType> = Partial<
+type FormErrors<SchemaType> = Partial<
   Record<keyof SchemaType | '_global', string[]>
 >
 
-export type PerformMutation<SchemaType, D extends unknown> =
+type PerformMutation<SchemaType, D extends unknown> =
   | ({ success: false } & FormActionFailure<SchemaType>)
   | { success: true; data: D }
 
-export type Callback = (request: Request) => Promise<Response | void>
+type Callback = (request: Request) => Promise<Response | void>
 
-export type PerformMutationProps<
-  Schema extends SomeZodObject,
-  D extends unknown,
-> = {
+type PerformMutationProps<Schema extends SomeZodObject, D extends unknown> = {
   request: Request
   schema: Schema
   mutation: DomainFunction<D>
   environment?: unknown
 }
 
-export type FormActionProps<Schema extends SomeZodObject, D extends unknown> = {
+type FormActionProps<Schema extends SomeZodObject, D extends unknown> = {
   beforeAction?: Callback
   beforeSuccess?: Callback
   successPath?: string | ((data: D) => string)
 } & PerformMutationProps<Schema, D>
 
-export async function performMutation<
+async function performMutation<
   Schema extends SomeZodObject,
   D extends unknown,
 >({
@@ -69,10 +67,7 @@ export async function performMutation<
   }
 }
 
-export async function formAction<
-  Schema extends SomeZodObject,
-  D extends unknown,
->({
+async function formAction<Schema extends SomeZodObject, D extends unknown>({
   request,
   schema,
   mutation,
@@ -107,3 +102,13 @@ export async function formAction<
     return json({ errors: result.errors, values: result.values })
   }
 }
+
+export type {
+  FormValues,
+  FormErrors,
+  PerformMutation,
+  Callback,
+  PerformMutationProps,
+  FormActionProps,
+}
+export { performMutation, formAction }

--- a/packages/remix-forms/src/getFormValues.ts
+++ b/packages/remix-forms/src/getFormValues.ts
@@ -1,9 +1,9 @@
 import { inputFromForm } from 'remix-domains'
-import { SomeZodObject, z } from 'zod'
+import type { SomeZodObject, z } from 'zod'
 import { coerceValue } from './coercions'
-import { FormValues } from './formAction.server'
+import type { FormValues } from './formAction.server'
 
-export default async function getFormValues<Schema extends SomeZodObject>(
+async function getFormValues<Schema extends SomeZodObject>(
   request: Request,
   schema: Schema,
 ): Promise<FormValues<z.infer<Schema>>> {
@@ -18,3 +18,5 @@ export default async function getFormValues<Schema extends SomeZodObject>(
 
   return values
 }
+
+export { getFormValues }

--- a/packages/remix-forms/src/inferLabel.test.ts
+++ b/packages/remix-forms/src/inferLabel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import inferLabel from './inferLabel'
+import { inferLabel } from './inferLabel'
 
 describe('inferLabel', () => {
   it('capitalizes the field name', () => {

--- a/packages/remix-forms/src/inferLabel.ts
+++ b/packages/remix-forms/src/inferLabel.ts
@@ -1,5 +1,7 @@
-import startCase from './startCase'
+import { startCase } from './startCase'
 
-export default function inferLabel(fieldName: string) {
+function inferLabel(fieldName: string) {
   return startCase(fieldName).replace(/Url/g, 'URL')
 }
+
+export { inferLabel }

--- a/packages/remix-forms/src/mapChildren.ts
+++ b/packages/remix-forms/src/mapChildren.ts
@@ -1,6 +1,6 @@
-import React from 'react'
+import * as React from 'react'
 
-export default function mapChildren(
+function mapChildren(
   children: React.ReactNode,
   fn: (child: React.ReactNode) => React.ReactNode,
 ): React.ReactNode {
@@ -19,3 +19,5 @@ export default function mapChildren(
     return fn(child)
   })
 }
+
+export { mapChildren }

--- a/packages/remix-forms/src/shapeInfo.ts
+++ b/packages/remix-forms/src/shapeInfo.ts
@@ -1,4 +1,4 @@
-import { ZodTypeAny } from 'zod'
+import type { ZodTypeAny } from 'zod'
 
 type ZodTypeName =
   | 'ZodString'

--- a/packages/remix-forms/src/startCase.test.ts
+++ b/packages/remix-forms/src/startCase.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import startCase from './startCase'
+import { startCase } from './startCase'
 
 describe('startCase', () => {
   it('capitalizes the first letter of every word', () => {

--- a/packages/remix-forms/src/startCase.ts
+++ b/packages/remix-forms/src/startCase.ts
@@ -1,8 +1,10 @@
 // source: https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/toTitleCase.md
 
-export default function startCase(str: string): string {
+function startCase(str: string): string {
   const matches = str.match(
     /[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g,
   ) ?? ['']
   return matches.map((x) => x.charAt(0).toUpperCase() + x.slice(1)).join(' ')
 }
+
+export { startCase }


### PR DESCRIPTION
I'm leveraging the turborepo eslint package for the whole monorepo, this way we follow the same style for both the website and the package.

We are also need to maintain only one eslint configuration.

Other than autofix I've also adopted the "export the whole public API in the end of the file" style on remix-forms package.
Some files were already following this approach so at least now we have a pattern ;)