### PR TITLE
React hook form as a peerdependency

### DIFF
--- a/apps/web/app/routes/get-started.tsx
+++ b/apps/web/app/routes/get-started.tsx
@@ -150,6 +150,10 @@ export default function Component() {
         <ExternalLink href="https://github.com/colinhacks/zod">
           Zod
         </ExternalLink>
+        ,{' '}
+        <ExternalLink href="https://react-hook-form.com/">
+          React Hook Form
+        </ExternalLink>
         , and{' '}
         <ExternalLink href="https://github.com/SeasonedSoftware/remix-domains">
           Remix Domains
@@ -157,7 +161,11 @@ export default function Component() {
         in your project before using Remix Forms.
       </p>
       <SubHeading>Installation</SubHeading>
-      <Pre>npm install remix-forms</Pre>
+      <p>
+        Assuming you already have <code>react</code> and <code>remix</code>{' '}
+        installed, you'll need the following packages:
+      </p>
+      <Pre>npm install remix-forms remix-domains zod react-hook-form</Pre>
       <SubHeading>Basic styles</SubHeading>
       <p>
         Remix Forms doesn&apos;t ship any styles, so you need to configure basic

--- a/package-lock.json
+++ b/package-lock.json
@@ -38719,8 +38719,7 @@
       "version": "0.17.4-rc.0",
       "license": "MIT",
       "dependencies": {
-        "@hookform/resolvers": "^2.8.8",
-        "react-hook-form": "^7.27.1"
+        "@hookform/resolvers": "^2.8.8"
       },
       "devDependencies": {
         "@remix-run/dev": "^1.4.1",
@@ -38741,6 +38740,7 @@
         "@remix-run/react": ">=1.2",
         "@remix-run/server-runtime": ">=1.2",
         "react": ">=16.8",
+        "react-hook-form": ">=7.27",
         "remix-domains": ">=0.2.0",
         "zod": ">=3.12"
       }
@@ -62896,7 +62896,6 @@
         "eslint": "^7.32.0",
         "eslint-config-custom": "*",
         "react": "^17.0.2",
-        "react-hook-form": "^7.27.1",
         "tsconfig": "*",
         "tsup": "^6.1.3",
         "typescript": "^4.5.2",

--- a/packages/remix-forms/package.json
+++ b/packages/remix-forms/package.json
@@ -16,6 +16,7 @@
     "@remix-run/react": ">=1.2",
     "@remix-run/server-runtime": ">=1.2",
     "react": ">=16.8",
+    "react-hook-form": ">=7.27",
     "remix-domains": ">=0.2.0",
     "zod": ">=3.12"
   },
@@ -35,7 +36,6 @@
     "vitest": "^0.10.0"
   },
   "dependencies": {
-    "@hookform/resolvers": "^2.8.8",
-    "react-hook-form": "^7.27.1"
+    "@hookform/resolvers": "^2.8.8"
   }
 }


### PR DESCRIPTION
Still following @tavoyne suggestions from #62 we are going to be requiring react-hook-form as a peerDependency.
I think it is pretty safe to do it given we are already assuming the users have this lib installed in most of our examples.

The results on the size of the lib are quite good:
from 16.2kb down to 3.9kb gzipped