### PR TITLE
Deprecate parseActionData

### DIFF
--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -143,6 +143,7 @@ type FormProps<Schema extends FormSchema> = {
   multiline?: Array<keyof z.infer<Schema>>
   beforeChildren?: React.ReactNode
   onTransition?: OnTransition<ObjectFromSchema<Schema>>
+  /** @deprecated use your custom json/useActionData in createFormAction/createForm instead */
   parseActionData?: (data: any) => any
   children?: Children<ObjectFromSchema<Schema>>
 } & Omit<BaseFormPropsWithHTMLAttributes, 'children'>


### PR DESCRIPTION
This feature is undocumented but we use it for our `superjson` serialization.

Now if you want to serialize the action data with something as json, instead of doing this:
```ts
import { deserialize } from 'superjson'

<RemixForm<Schema> parseActionData={deserialize} />
```

You should be able to do this:
```ts
// form.tsx
import {
  Form as FrameworkForm,
  useSubmit,
  useTransition as useNavigation,
} from '@remix-run/react'
import { useActionData } from '~/my-framework'

const RemixForm = createForm({
  component: FrameworkForm,
  useNavigation,
  useSubmit,
  useActionData,
})

// form-action.server.ts
import { redirect } from '@remix-run/node'
import { createFormAction } from 'remix-forms'
import { json } from '~/my-framework'

const formAction = createFormAction({ redirect, json })
```