### PR TITLE
Add autoFocus prop to form

### DIFF
--- a/apps/web/app/routes/examples/forms/field-layout.tsx
+++ b/apps/web/app/routes/examples/forms/field-layout.tsx
@@ -25,7 +25,7 @@ const code = `const schema = z.object({
 })
 
 export default () => (
-  <Form schema={schema}>
+  <Form schema={schema} autoFocus="street">
     {({ Field, Errors, Button }) => (
       <>
         <div className="flex space-x-4">
@@ -64,7 +64,7 @@ export const action: ActionFunction = async ({ request }) =>
 export default function Component() {
   return (
     <Example title={title} description={description}>
-      <Form schema={schema}>
+      <Form schema={schema} autoFocus="street">
         {({ Field, Errors, Button }) => (
           <>
             <div className="flex space-x-4">

--- a/apps/web/app/routes/examples/forms/labels-and-options.tsx
+++ b/apps/web/app/routes/examples/forms/labels-and-options.tsx
@@ -26,6 +26,7 @@ const code = `const schema = z.object({
 export default () => (
   <Form
     schema={schema}
+    autoFocus="name"
     labels={{ roleId: 'Role' }}
     placeholders={{ name: 'Your name', bio: 'Your story' }}
     options={{
@@ -59,6 +60,7 @@ export default function Component() {
     <Example title={title} description={description}>
       <Form
         schema={schema}
+        autoFocus="name"
         labels={{ roleId: 'Role' }}
         placeholders={{ name: 'Your name', bio: 'Your story' }}
         options={{

--- a/apps/web/tests/examples/forms/field-layout.spec.ts
+++ b/apps/web/tests/examples/forms/field-layout.spec.ts
@@ -19,6 +19,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectField(city)
   await example.expectSelect(state, { value: '' })
   await expect(button).toBeEnabled()
+  await expect(street.input).toBeFocused()
 
   // Client-side validation
   await button.click()
@@ -76,6 +77,7 @@ testWithoutJS('With JS disabled', async ({ example }) => {
   const state = example.field('state')
 
   await page.goto(route)
+  await example.expectAutoFocus(street)
 
   // Server-side validation
   await button.click()

--- a/apps/web/tests/examples/forms/labels-and-options.spec.ts
+++ b/apps/web/tests/examples/forms/labels-and-options.spec.ts
@@ -18,6 +18,7 @@ test('With JS enabled', async ({ example }) => {
   await expect(options.first()).toHaveText('Designer')
   await expect(options.last()).toHaveText('Dev')
   await expect(button).toBeEnabled()
+  await expect(name.input).toBeFocused()
 
   // Client-side validation
   await button.click()
@@ -59,6 +60,7 @@ testWithoutJS('With JS disabled', async ({ example }) => {
   const bio = example.field('bio')
 
   await page.goto(route)
+  await example.expectAutoFocus(name)
 
   // Server-side validation
   await button.click()
@@ -75,7 +77,6 @@ testWithoutJS('With JS disabled', async ({ example }) => {
   await button.click()
   await page.reload()
   await example.expectValid(name)
-  await example.expectNoAutoFocus(name)
   await example.expectAutoFocus(bio)
 
   // Make form be valid and test selecting an option

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -144,6 +144,7 @@ type FormProps<Schema extends FormSchema> = {
   options?: Options<z.infer<Schema>>
   hiddenFields?: Array<keyof z.infer<Schema>>
   multiline?: Array<keyof z.infer<Schema>>
+  autoFocus?: keyof z.infer<Schema>
   beforeChildren?: React.ReactNode
   onTransition?: OnTransition<ObjectFromSchema<Schema>>
   /** @deprecated use your custom json/useActionData in createFormAction/createForm instead */
@@ -199,6 +200,7 @@ function createForm({
     options,
     hiddenFields,
     multiline,
+    autoFocus: autoFocusProp,
     errors: errorsProp,
     values: valuesProp,
     ...props
@@ -307,7 +309,7 @@ function createForm({
         label: (labels && labels[key]) || inferLabel(String(key)),
         options: required ? fieldOptions : fieldOptionsPlusEmpty(),
         errors: fieldErrors(key),
-        autoFocus: key === firstErroredField,
+        autoFocus: key === firstErroredField || key === autoFocusProp,
         value: defaultValues[key],
         hidden:
           hiddenFields && Boolean(hiddenFields.find((item) => item === key)),
@@ -340,7 +342,7 @@ function createForm({
 
           const autoFocus = firstErroredField
             ? field?.autoFocus
-            : child.props.autoFocus
+            : child.props.autoFocus ?? field?.autoFocus
 
           if (!child.props.children && field) {
             return renderField({


### PR DESCRIPTION
That will allow us to set a field to auto-focus on without having to pass children to `Form`.