### PR TITLE
Fix phone regex example, the '\' was being hidden by the template string

### DIFF
--- a/apps/web/app/routes/examples/schemas/strings.tsx
+++ b/apps/web/app/routes/examples/schemas/strings.tsx
@@ -29,7 +29,7 @@ const code = `const schema = z.object({
   phoneNumber: z
     .string()
     .regex(
-      /^[+]?[(]?[0-9]{3}[)]?[-\s.]?[0-9]{3}[-\s.]?[0-9]{4,6}$/im,
+      /^[+]?[(]?[0-9]{3}[)]?[-\\s.]?[0-9]{3}[-\\s.]?[0-9]{4,6}$/im,
       'Invalid phone number',
     ),
 })


### PR DESCRIPTION
![Screenshot_2022-11-16_at_12_25_40](https://user-images.githubusercontent.com/566971/202222028-7512bfa4-66e0-47ba-915c-3fd9bb7179ba.jpg)
