### PR TITLE
radio improvements take 2

### DIFF
--- a/apps/web/styles/app.css
+++ b/apps/web/styles/app.css
@@ -2,20 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
-sub,
-sup {
-  font-size: 60%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
+@layer base {
+  label[for] {
+    @apply cursor-pointer;
+  }
 
-sup {
-  top: 0;
-  vertical-align: super;
-}
+  sub,
+  sup {
+    font-size: 60%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
 
-sub {
-  bottom: 0;
-  vertical-align: sub;
+  sup {
+    top: 0;
+    vertical-align: super;
+  }
+
+  sub {
+    bottom: 0;
+    vertical-align: sub;
+  }
 }

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -406,6 +406,11 @@ function createField<Schema extends SomeZodObject>({
                   defaultChecked: Boolean(value),
                   ...child.props,
                 })
+              } else if (child.type === RadioGroup) {
+                return React.cloneElement(child, {
+                  ...a11yProps,
+                  ...child.props,
+                })
               } else if (child.type === Errors) {
                 if (!child.props.children && !errors?.length) return null
 

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -62,6 +62,15 @@ const types: Record<FieldType, React.HTMLInputTypeAttribute> = {
   date: 'date',
 }
 
+function getInputType(
+  type: FieldType,
+  radio: boolean,
+): React.HTMLInputTypeAttribute {
+  if (radio) return 'radio'
+
+  return types[type]
+}
+
 type FieldBaseProps<Schema extends SomeZodObject> = Omit<
   Partial<Field<z.infer<Schema>>>,
   'name'
@@ -276,7 +285,7 @@ function createField<Schema extends SomeZodObject>({
         : undefined
 
       const style = hidden ? { display: 'none' } : undefined
-      const type = typeProp ?? types[fieldType]
+      const type = typeProp ?? getInputType(fieldType, radio)
 
       const registerProps = register(String(name), {
         setValueAs: (value) => coerceValue(value, shape),
@@ -409,6 +418,15 @@ function createField<Schema extends SomeZodObject>({
               } else if (child.type === RadioGroup) {
                 return React.cloneElement(child, {
                   ...a11yProps,
+                  ...child.props,
+                })
+              } else if (child.type === Radio) {
+                return React.cloneElement(child, {
+                  id: `${name}-${child.props.value}`,
+                  type,
+                  autoFocus,
+                  ...registerProps,
+                  defaultChecked: value === child.props.value,
                   ...child.props,
                 })
               } else if (child.type === Errors) {


### PR DESCRIPTION
This PR is supposed to split #113 in two parts. The commits bellow do not require any change to `mapChildren`.

- Pass a11y props to RadioGroup inside Field children
- Pass correct props to Radio inside Field children 
- Add pointer cursor to labels
