### PR TITLE
Revalidate (or at least clean) server errors on input change

### DIFF
--- a/apps/web/tests/examples/actions/field-error.spec.ts
+++ b/apps/web/tests/examples/actions/field-error.spec.ts
@@ -1,6 +1,33 @@
 import { test, testWithoutJS, expect } from 'tests/setup/tests'
 
 const route = '/examples/actions/field-error'
+test('With JS enabled clear server error on the client', async ({ example }) => {
+  const { email, password, button, page } = example
+
+  await page.goto(route)
+
+  // Render
+  await example.expectField(email)
+  await example.expectField(password)
+  await expect(button).toBeEnabled()
+
+  // Make generate server error
+  await email.input.fill('foo@bar.com')
+  await example.expectValid(email)
+  await password.input.fill('123456')
+  await example.expectValid(password)
+
+  // Submit form
+  button.click()
+  await expect(button).toBeDisabled()
+
+  // Show field error
+  await example.expectError(email, 'Email already taken')
+
+  // Submit valid form
+  await email.input.fill('john@doe.com')
+  await example.expectValid(email)
+})
 
 test('With JS enabled', async ({ example }) => {
   const { email, password, button, page } = example

--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -41,5 +41,9 @@ function parseDate(value?: Date | string) {
   return date
 }
 
-export { objectFromSchema, mapObject, parseDate }
+function browser(): boolean {
+  return typeof document === 'object'
+}
+
+export { objectFromSchema, mapObject, parseDate, browser }
 export type { FormSchema, ObjectFromSchema, ComponentOrTagName, KeysOfStrings }


### PR DESCRIPTION
## Purpose

If we get an error coming from the server action and render it as a field error, it's safe to assume that upon changing that field value we should cease to see the error.
Since an error depends on the field and its value, and changing the value turns the error to an unknown state.

This should address #111.

Note that with the current shape of this PR is that we can't really revalidate unless we resubmit the form, and doing this on behalf of the user would be reckless at best.

It seems safer to clean the error state and allow the user to resubmit to get a new validation from the server.

TODO:

- [x] Implement a test case
