### PR TITLE
Fix hook order on Form

### DIFF
--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -184,12 +184,12 @@ function createForm({
   }: FormProps<Schema>) {
     type SchemaType = z.infer<Schema>
     const Component = fetcher?.Form ?? component
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const submit = fetcher?.submit ?? useSubmit()
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const transition = fetcher ?? useNavigation()
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const unparsedActionData = fetcher?.data ?? useActionData()
+    const navigationSubmit = useSubmit()
+    const submit = fetcher?.submit ?? navigationSubmit
+    const navigationTransition = useNavigation()
+    const transition = fetcher ?? navigationTransition
+    const navigationActionData = useActionData()
+    const unparsedActionData = fetcher?.data ?? navigationActionData
 
     const actionData =
       parseActionData && unparsedActionData


### PR DESCRIPTION
When running the [useFetcher](https://remix-forms.seasoned.cc/examples/forms/use-fetcher) example locally, we get a warning that React detected a change in the hook order. That's because we wanted to save a couple of constants in our form and used hooks conditionally 😅 this PR fixes it.