### PR TITLE
Show hidden input errors as global errors

### DIFF
--- a/apps/web/app/routes/test-examples/hidden-field-with-errors.tsx
+++ b/apps/web/app/routes/test-examples/hidden-field-with-errors.tsx
@@ -1,0 +1,40 @@
+import hljs from 'highlight.js/lib/common'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
+import { formAction } from '~/formAction'
+import { z } from 'zod'
+import Form from '~/ui/form'
+import { metaTags } from '~/helpers'
+import { makeDomainFunction } from 'domain-functions'
+import Example from '~/ui/example'
+
+const title = 'Hidden fields with errors'
+const description =
+  'In this example, we ensure that errors in hidden fields are rendered as global form errors.'
+
+export const meta: MetaFunction = () => metaTags({ title, description })
+
+const schema = z.object({
+  csrfToken: z.string().min(1),
+  firstName: z.string().min(1),
+})
+
+export const loader: LoaderFunction = () => ({
+  code: hljs.highlight("", { language: 'ts' }).value,
+})
+
+const mutation = makeDomainFunction(schema)(async (values) => values)
+
+export const action: ActionFunction = async ({ request }) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <Form schema={schema} errors={{ _global: ["Some prop error"] }} hiddenFields={["csrfToken"]} />
+    </Example>
+  )
+}

--- a/apps/web/tests/examples/actions/global-error.spec.ts
+++ b/apps/web/tests/examples/actions/global-error.spec.ts
@@ -46,9 +46,7 @@ test('With JS enabled', async ({ example }) => {
   await expect(button).toBeDisabled()
 
   // Show global error
-  await expect(page.locator('form > div[role="alert"]:visible')).toHaveText(
-    'Wrong email or password',
-  )
+  await example.expectGlobalError('Wrong email or password')
 
   // Submit valid form
   await password.input.fill('supersafe')

--- a/apps/web/tests/examples/forms/hidden-field-with-errors.spec.ts
+++ b/apps/web/tests/examples/forms/hidden-field-with-errors.spec.ts
@@ -1,0 +1,47 @@
+import { test, testWithoutJS, expect } from 'tests/setup/tests'
+
+const route = '/test-examples/hidden-field-with-errors'
+
+test('With JS enabled', async ({ example }) => {
+  const { firstName, button, page } = example
+  await page.goto(route)
+
+  // Render
+  await example.expectField(firstName)
+  await expect(button).toBeEnabled()
+
+  // Client-side validation
+  await button.click()
+
+  // Show field errors and focus on the first field
+
+  await example.expectError(
+    firstName,
+    'String must contain at least 1 character(s)',
+  )
+  await example.expectGlobalError(
+    'Some prop errorCsrf Token: String must contain at least 1 character(s)',
+  )
+})
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { firstName, button, page } = example
+  await page.goto(route)
+
+  // Render
+  await example.expectField(firstName)
+  await expect(button).toBeEnabled()
+
+  // Client-side validation
+  await button.click()
+
+  // Show field errors and focus on the first field
+
+  await example.expectError(
+    firstName,
+    'String must contain at least 1 character(s)',
+  )
+  await example.expectGlobalError(
+    'Some prop errorCsrf Token: String must contain at least 1 character(s)',
+  )
+})

--- a/apps/web/tests/setup/example.ts
+++ b/apps/web/tests/setup/example.ts
@@ -123,6 +123,12 @@ class Example {
     await this.expectErrorMessage(field.name, message)
   }
 
+  async expectGlobalError(message: string) {
+    await expect(
+      this.page.locator('form > div[role="alert"]:visible'),
+    ).toHaveText(message)
+  }
+
   async expectErrorMessage(fieldName: string, message: string) {
     await expect(
       this.page.locator(`#errors-for-${fieldName}:visible`),

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -302,7 +302,20 @@ function createForm({
       } as Field<SchemaType>
     }
 
-    const globalErrors = errors?._global
+    let hiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
+      const hiddenFieldErrors = fieldErrors(hiddenField)
+
+      if (Array.isArray(hiddenFieldErrors)) {
+        const hiddenFieldLabel =
+          (labels && labels[hiddenField]) || inferLabel(String(hiddenField))
+        return hiddenFieldErrors.map((error) => `${hiddenFieldLabel}: ${error}`)
+      }
+    })
+    hiddenFieldsErrors = hiddenFieldsErrors?.flat()
+
+    let globalErrors = []
+      .concat(errors?._global, hiddenFieldsErrors)
+      .filter((error) => typeof error === 'string')
 
     const buttonLabel =
       transition.state === 'submitting' ? pendingButtonLabel : rawButtonLabel
@@ -383,7 +396,7 @@ function createForm({
         {Object.keys(schemaShape)
           .map(makeField)
           .map((field) => renderField({ Field, ...field }))}
-        {globalErrors?.length && (
+        {globalErrors?.length > 0 && (
           <Errors role="alert">
             {globalErrors.map((error) => (
               <Error key={error}>{error}</Error>

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -302,19 +302,19 @@ function createForm({
       } as Field<SchemaType>
     }
 
-    let hiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
+    const deepHiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
       const hiddenFieldErrors = fieldErrors(hiddenField)
 
-      if (Array.isArray(hiddenFieldErrors)) {
+      if (hiddenFieldErrors?.length) {
         const hiddenFieldLabel =
           (labels && labels[hiddenField]) || inferLabel(String(hiddenField))
         return hiddenFieldErrors.map((error) => `${hiddenFieldLabel}: ${error}`)
-      }
+      } else return []
     })
-    hiddenFieldsErrors = hiddenFieldsErrors?.flat()
+    const hiddenFieldsErrors: string[] = deepHiddenFieldsErrors?.flat() || []
 
-    let globalErrors = []
-      .concat(errors?._global, hiddenFieldsErrors)
+    let globalErrors = ([] as string[])
+      .concat(errors?._global || [], hiddenFieldsErrors)
       .filter((error) => typeof error === 'string')
 
     const buttonLabel =

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -302,20 +302,28 @@ function createForm({
       } as Field<SchemaType>
     }
 
-    const deepHiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
-      const hiddenFieldErrors = fieldErrors(hiddenField)
+    const hiddenFieldsErrorsToGlobal = (globalErrors: string[] = []) => {
+      const deepHiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
+        const hiddenFieldErrors = fieldErrors(hiddenField)
 
-      if (hiddenFieldErrors?.length) {
-        const hiddenFieldLabel =
-          (labels && labels[hiddenField]) || inferLabel(String(hiddenField))
-        return hiddenFieldErrors.map((error) => `${hiddenFieldLabel}: ${error}`)
-      } else return []
-    })
-    const hiddenFieldsErrors: string[] = deepHiddenFieldsErrors?.flat() || []
+        if (hiddenFieldErrors?.length) {
+          const hiddenFieldLabel =
+            (labels && labels[hiddenField]) || inferLabel(String(hiddenField))
+          return hiddenFieldErrors.map(
+            (error) => `${hiddenFieldLabel}: ${error}`,
+          )
+        } else return []
+      })
+      const hiddenFieldsErrors: string[] = deepHiddenFieldsErrors?.flat() || []
 
-    let globalErrors = ([] as string[])
-      .concat(errors?._global || [], hiddenFieldsErrors)
-      .filter((error) => typeof error === 'string')
+      const allGlobalErrors = ([] as string[])
+        .concat(globalErrors, hiddenFieldsErrors)
+        .filter((error) => typeof error === 'string')
+
+      return allGlobalErrors.length > 0 ? allGlobalErrors : undefined
+    }
+
+    let globalErrors = hiddenFieldsErrorsToGlobal(errors?._global)
 
     const buttonLabel =
       transition.state === 'submitting' ? pendingButtonLabel : rawButtonLabel
@@ -396,7 +404,7 @@ function createForm({
         {Object.keys(schemaShape)
           .map(makeField)
           .map((field) => renderField({ Field, ...field }))}
-        {globalErrors?.length > 0 && (
+        {globalErrors?.length && (
           <Errors role="alert">
             {globalErrors.map((error) => (
               <Error key={error}>{error}</Error>

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -306,7 +306,7 @@ function createForm({
       const deepHiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
         const hiddenFieldErrors = fieldErrors(hiddenField)
 
-        if (hiddenFieldErrors?.length) {
+        if (hiddenFieldErrors instanceof Array) {
           const hiddenFieldLabel =
             (labels && labels[hiddenField]) || inferLabel(String(hiddenField))
           return hiddenFieldErrors.map(


### PR DESCRIPTION
Related issue: #10
Merges hidden field errors from any source (props, mutations, client-side validation) into global errors in order to show them to the user. 