### PR TITLE
Wrap fields with context to expose a `useField` hook

### DIFF
--- a/apps/web/app/routes/examples.tsx
+++ b/apps/web/app/routes/examples.tsx
@@ -94,6 +94,9 @@ export default function Component() {
           <SidebarLayout.NavLink to={'/examples/forms/use-form-state'}>
             useFormState
           </SidebarLayout.NavLink>
+          <SidebarLayout.NavLink to={'/examples/forms/use-field'}>
+            useField
+          </SidebarLayout.NavLink>
           <SidebarLayout.NavLink to={'/examples/forms/multiple-forms'}>
             Multiple forms
           </SidebarLayout.NavLink>

--- a/apps/web/app/routes/examples/forms/use-field.tsx
+++ b/apps/web/app/routes/examples/forms/use-field.tsx
@@ -1,0 +1,156 @@
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
+import { makeDomainFunction } from 'domain-functions'
+import hljs from 'highlight.js/lib/common'
+import * as React from 'react'
+import { useField } from 'remix-forms'
+import { z } from 'zod'
+import { formAction } from '~/formAction'
+import { cx, metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import Form from '~/ui/form'
+
+const title = 'useField'
+const description = `In this example, we use the useField hook to display error, dirty and required indicators in custom components.`
+
+export const meta: MetaFunction = () => metaTags({ title, description })
+
+const code = `const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+const Label = ({ children, ...props }: JSX.IntrinsicElements['label']) => {
+  const { required, errors, dirty } = useField()
+  return (
+    <label
+      className={errors ? 'text-red-600' : dirty ? 'text-yellow-600' : 'text-gray-400'}
+      {...props}
+    >
+      {children}
+      {required && <sup>*</sup>}
+    </label>
+  )
+}
+const Input = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>(({ type = 'text', ...props }, ref) => {
+  const { errors, dirty } = useField()
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={errors
+          ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
+          : dirty
+          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
+          : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
+      }
+      {...props}
+    />
+  )
+})
+
+// Select component similar to Input
+
+export default () => (
+  <Form
+    schema={schema}
+    values={{ email: 'default@domain.tld', preferredSport: 'Basketball' }}
+    labelComponent={Label}
+    inputComponent={Input}
+    selectComponent={Select}
+  />
+)`
+
+const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export const loader: LoaderFunction = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = makeDomainFunction(schema)(async (values) => values)
+
+export const action: ActionFunction = async ({ request }) =>
+  formAction({ request, schema, mutation })
+
+const Label = ({ children, ...props }: JSX.IntrinsicElements['label']) => {
+  const { required, errors, dirty } = useField()
+  return (
+    <label
+      className={cx(
+        'block font-medium',
+        errors ? 'text-red-600' : dirty ? 'text-yellow-600' : 'text-gray-400',
+      )}
+      {...props}
+    >
+      {children}
+      {required && <sup>*</sup>}
+    </label>
+  )
+}
+const Input = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>(({ type = 'text', ...props }, ref) => {
+  const { errors, dirty } = useField()
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={cx(
+        'block w-full rounded-md text-gray-800 shadow-sm sm:text-sm',
+        errors
+          ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
+          : dirty
+          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
+          : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
+      )}
+      {...props}
+    />
+  )
+})
+
+const Select = React.forwardRef<
+  HTMLSelectElement,
+  JSX.IntrinsicElements['select']
+>((props, ref) => {
+  const { errors, dirty } = useField()
+  return (
+    <select
+      ref={ref}
+      className={cx(
+        'block w-full rounded-md py-2 pl-3 pr-10 text-base text-gray-800 focus:outline-none sm:text-sm',
+        errors
+          ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
+          : dirty
+          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
+          : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
+      )}
+      {...props}
+    />
+  )
+})
+
+export default () => (
+  <Example title={title} description={description}>
+    <Form
+      schema={schema}
+      values={{ email: 'default@domain.tld', preferredSport: 'Basketball' }}
+      labelComponent={Label}
+      inputComponent={Input}
+      selectComponent={Select}
+    />
+  </Example>
+)

--- a/apps/web/app/routes/examples/forms/use-field.tsx
+++ b/apps/web/app/routes/examples/forms/use-field.tsx
@@ -20,7 +20,7 @@ export const meta: MetaFunction = () => metaTags({ title, description })
 
 const code = `const schema = z.object({
   email: z.string().email(),
-  firstName: z.string().min(1),
+  firstName: z.string().optional(),
   preferredSport: z.enum(['Basketball', 'Football', 'Other']),
   newsletter: z.boolean().default(false),
 })
@@ -71,7 +71,7 @@ export default () => (
 
 const schema = z.object({
   email: z.string().email(),
-  firstName: z.string().min(1),
+  firstName: z.string().optional(),
   preferredSport: z.enum(['Basketball', 'Football', 'Other']),
   newsletter: z.boolean().default(false),
 })
@@ -143,14 +143,40 @@ const Select = React.forwardRef<
   )
 })
 
+const Checkbox = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>(({ type = 'checkbox', className, ...props }, ref) => {
+  const { errors, dirty } = useField()
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={cx(
+        'h-4 w-4 rounded',
+        errors
+          ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
+          : dirty
+          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
+          : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
+      )}
+      {...props}
+    />
+  )
+})
+
 export default () => (
   <Example title={title} description={description}>
     <Form
       schema={schema}
-      values={{ email: 'default@domain.tld', preferredSport: 'Basketball' }}
+      values={{
+        email: 'default@domain.tld',
+        preferredSport: 'Basketball',
+      }}
       labelComponent={Label}
       inputComponent={Input}
       selectComponent={Select}
+      checkboxComponent={Checkbox}
     />
   </Example>
 )

--- a/apps/web/app/routes/examples/forms/use-field.tsx
+++ b/apps/web/app/routes/examples/forms/use-field.tsx
@@ -20,36 +20,19 @@ export const meta: MetaFunction = () => metaTags({ title, description })
 
 const code = `const schema = z.object({
   email: z.string().email(),
-  firstName: z.string().optional(),
-  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
-  newsletter: z.boolean().default(false),
 })
 
-const Label = ({ children, ...props }: JSX.IntrinsicElements['label']) => {
-  const { required, errors, dirty } = useField()
-  return (
-    <label
-      className={errors ? 'text-red-600' : dirty ? 'text-yellow-600' : 'text-gray-400'}
-      {...props}
-    >
-      {children}
-      {required && <sup>*</sup>}
-    </label>
-  )
-}
 const Input = React.forwardRef<
   HTMLInputElement,
   JSX.IntrinsicElements['input']
 >(({ type = 'text', ...props }, ref) => {
-  const { errors, dirty } = useField()
+  const { errors } = useField()
   return (
     <input
       ref={ref}
       type={type}
       className={errors
           ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
-          : dirty
-          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
           : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
       }
       {...props}
@@ -57,23 +40,12 @@ const Input = React.forwardRef<
   )
 })
 
-// Select component similar to Input
-
 export default () => (
-  <Form
-    schema={schema}
-    values={{ email: 'default@domain.tld', preferredSport: 'Basketball' }}
-    labelComponent={Label}
-    inputComponent={Input}
-    selectComponent={Select}
-  />
+  <Form schema={schema} inputComponent={Input} />
 )`
 
 const schema = z.object({
   email: z.string().email(),
-  firstName: z.string().optional(),
-  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
-  newsletter: z.boolean().default(false),
 })
 
 export const loader: LoaderFunction = () => ({
@@ -85,26 +57,11 @@ const mutation = makeDomainFunction(schema)(async (values) => values)
 export const action: ActionFunction = async ({ request }) =>
   formAction({ request, schema, mutation })
 
-const Label = ({ children, ...props }: JSX.IntrinsicElements['label']) => {
-  const { required, errors, dirty } = useField()
-  return (
-    <label
-      className={cx(
-        'block font-medium',
-        errors ? 'text-red-600' : dirty ? 'text-yellow-600' : 'text-gray-400',
-      )}
-      {...props}
-    >
-      {children}
-      {required && <sup>*</sup>}
-    </label>
-  )
-}
 const Input = React.forwardRef<
   HTMLInputElement,
   JSX.IntrinsicElements['input']
 >(({ type = 'text', ...props }, ref) => {
-  const { errors, dirty } = useField()
+  const { errors } = useField()
   return (
     <input
       ref={ref}
@@ -113,51 +70,6 @@ const Input = React.forwardRef<
         'block w-full rounded-md text-gray-800 shadow-sm sm:text-sm',
         errors
           ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
-          : dirty
-          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
-          : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
-      )}
-      {...props}
-    />
-  )
-})
-
-const Select = React.forwardRef<
-  HTMLSelectElement,
-  JSX.IntrinsicElements['select']
->((props, ref) => {
-  const { errors, dirty } = useField()
-  return (
-    <select
-      ref={ref}
-      className={cx(
-        'block w-full rounded-md py-2 pl-3 pr-10 text-base text-gray-800 focus:outline-none sm:text-sm',
-        errors
-          ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
-          : dirty
-          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
-          : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
-      )}
-      {...props}
-    />
-  )
-})
-
-const Checkbox = React.forwardRef<
-  HTMLInputElement,
-  JSX.IntrinsicElements['input']
->(({ type = 'checkbox', className, ...props }, ref) => {
-  const { errors, dirty } = useField()
-  return (
-    <input
-      ref={ref}
-      type={type}
-      className={cx(
-        'h-4 w-4 rounded',
-        errors
-          ? 'border-red-600 focus:border-red-600 focus:ring-red-600'
-          : dirty
-          ? 'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
           : 'border-gray-300 focus:border-pink-500 focus:ring-pink-500',
       )}
       {...props}
@@ -167,16 +79,6 @@ const Checkbox = React.forwardRef<
 
 export default () => (
   <Example title={title} description={description}>
-    <Form
-      schema={schema}
-      values={{
-        email: 'default@domain.tld',
-        preferredSport: 'Basketball',
-      }}
-      labelComponent={Label}
-      inputComponent={Input}
-      selectComponent={Select}
-      checkboxComponent={Checkbox}
-    />
+    <Form schema={schema} inputComponent={Input} />
   </Example>
 )

--- a/apps/web/tests/examples/forms/use-field.spec.ts
+++ b/apps/web/tests/examples/forms/use-field.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from 'tests/setup/tests'
+
+const route = '/examples/forms/use-field'
+
+test('With JS enabled', async ({ example }) => {
+  const { firstName, email, button, page } = example
+  const preferredSport = example.field('preferredSport')
+  const newsletter = example.field('newsletter')
+
+  await page.goto(route)
+
+  // Render
+  await example.expectField(email, {
+    label: 'Email*',
+    value: 'default@domain.tld',
+  })
+  await example.expectField(firstName, { required: false })
+  await example.expectSelect(preferredSport, {
+    label: 'Preferred Sport*',
+    value: 'Basketball',
+  })
+  const options = preferredSport.input.locator('option')
+  await expect(options.first()).toHaveText('Basketball')
+  await expect(options.nth(1)).toHaveText('Football')
+  await expect(options.last()).toHaveText('Other')
+  await expect(button).toBeEnabled()
+  await example.expectField(newsletter, {
+    label: 'Newsletter*',
+    type: 'checkbox',
+    value: 'on',
+  })
+
+  // Make fields dirty
+  await email.input.fill('john@doe.com')
+  await firstName.input.fill('John Doe')
+  await preferredSport.input.selectOption({ value: 'Other' })
+  await newsletter.input.check()
+
+  // Show fields that are dirty using a class
+  const dirtyClass =
+    'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
+
+  expect(await email.input.getAttribute('class')).toContain(dirtyClass)
+  expect(await firstName.input.getAttribute('class')).toContain(dirtyClass)
+  expect(await preferredSport.input.getAttribute('class')).toContain(dirtyClass)
+  expect(await newsletter.input.getAttribute('class')).toContain(dirtyClass)
+
+  // Blank email is still dirty since our original value is not blank
+  await email.input.fill('')
+  expect(await email.input.getAttribute('class')).toContain(dirtyClass)
+
+  // Clean up all fields
+  await email.input.fill('default@domain.tld')
+  await firstName.input.fill('')
+  await preferredSport.input.selectOption({ value: 'Basketball' })
+  await newsletter.input.uncheck()
+
+  expect(await email.input.getAttribute('class')).not.toContain(dirtyClass)
+  expect(await firstName.input.getAttribute('class')).not.toContain(dirtyClass)
+  expect(await preferredSport.input.getAttribute('class')).not.toContain(
+    dirtyClass,
+  )
+  expect(await newsletter.input.getAttribute('class')).not.toContain(dirtyClass)
+})

--- a/apps/web/tests/examples/forms/use-field.spec.ts
+++ b/apps/web/tests/examples/forms/use-field.spec.ts
@@ -3,62 +3,29 @@ import { test, expect } from 'tests/setup/tests'
 const route = '/examples/forms/use-field'
 
 test('With JS enabled', async ({ example }) => {
-  const { firstName, email, button, page } = example
-  const preferredSport = example.field('preferredSport')
-  const newsletter = example.field('newsletter')
+  const { email, button, page } = example
 
   await page.goto(route)
 
   // Render
   await example.expectField(email, {
-    label: 'Email*',
-    value: 'default@domain.tld',
+    label: 'Email',
   })
-  await example.expectField(firstName, { required: false })
-  await example.expectSelect(preferredSport, {
-    label: 'Preferred Sport*',
-    value: 'Basketball',
-  })
-  const options = preferredSport.input.locator('option')
-  await expect(options.first()).toHaveText('Basketball')
-  await expect(options.nth(1)).toHaveText('Football')
-  await expect(options.last()).toHaveText('Other')
   await expect(button).toBeEnabled()
-  await example.expectField(newsletter, {
-    label: 'Newsletter*',
-    type: 'checkbox',
-    value: 'on',
-  })
 
-  // Make fields dirty
-  await email.input.fill('john@doe.com')
-  await firstName.input.fill('John Doe')
-  await preferredSport.input.selectOption({ value: 'Other' })
-  await newsletter.input.check()
+  // Fill in an invalid email address
+  await email.input.fill('john@doe')
 
-  // Show fields that are dirty using a class
-  const dirtyClass =
-    'border-yellow-600 focus:border-yellow-600 focus:ring-yellow-600'
+  // Client-side validation
+  await button.click()
 
-  expect(await email.input.getAttribute('class')).toContain(dirtyClass)
-  expect(await firstName.input.getAttribute('class')).toContain(dirtyClass)
-  expect(await preferredSport.input.getAttribute('class')).toContain(dirtyClass)
-  expect(await newsletter.input.getAttribute('class')).toContain(dirtyClass)
+  // Show fields that are invalid using class
+  const invalidClass = 'border-red-600 focus:border-red-600 focus:ring-red-600'
 
-  // Blank email is still dirty since our original value is not blank
-  await email.input.fill('')
-  expect(await email.input.getAttribute('class')).toContain(dirtyClass)
+  expect(await email.input.getAttribute('class')).toContain(invalidClass)
 
-  // Clean up all fields
+  // Fill in a valid email
   await email.input.fill('default@domain.tld')
-  await firstName.input.fill('')
-  await preferredSport.input.selectOption({ value: 'Basketball' })
-  await newsletter.input.uncheck()
 
-  expect(await email.input.getAttribute('class')).not.toContain(dirtyClass)
-  expect(await firstName.input.getAttribute('class')).not.toContain(dirtyClass)
-  expect(await preferredSport.input.getAttribute('class')).not.toContain(
-    dirtyClass,
-  )
-  expect(await newsletter.input.getAttribute('class')).not.toContain(dirtyClass)
+  expect(await email.input.getAttribute('class')).not.toContain(invalidClass)
 })

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -358,20 +358,9 @@ function createField<Schema extends SomeZodObject>({
           Errors,
           Error,
           ref,
-          shape,
-          fieldType,
           name,
-          required,
-          label,
           type,
-          options,
-          errors,
-          autoFocus,
-          value,
-          hidden,
-          multiline,
-          radio,
-          placeholder,
+          ...field,
         })
 
         const children = mapChildren(childrenDefinition, (child) => {
@@ -445,7 +434,7 @@ function createField<Schema extends SomeZodObject>({
             })
           } else if (child.type === Radio) {
             return React.cloneElement(child, {
-              id: `${name}-${child.props.value}`,
+              id: `${String(name)}-${child.props.value}`,
               type: 'radio',
               autoFocus,
               ...registerProps,
@@ -474,23 +463,24 @@ function createField<Schema extends SomeZodObject>({
           }
         })
 
-        const fixRadioLabels = (children: React.ReactNode) => mapChildren(children, (child) => {
-          if (child.type === Label) {
-            const parent = findParent(children, child)
-            if (parent && parent.type === RadioWrapper) {
-              const radioChild = findElement(
-                parent.props?.children,
-                (ch) => ch.type === Radio,
-              )
-              if (radioChild) {
-                return React.cloneElement(child, {
-                  htmlFor: radioChild.props.id,
-                })
+        const fixRadioLabels = (children: React.ReactNode) =>
+          mapChildren(children, (child) => {
+            if (child.type === Label) {
+              const parent = findParent(children, child)
+              if (parent && parent.type === RadioWrapper) {
+                const radioChild = findElement(
+                  parent.props?.children,
+                  (ch) => ch.type === Radio,
+                )
+                if (radioChild) {
+                  return React.cloneElement(child, {
+                    htmlFor: radioChild.props.id,
+                  })
+                }
               }
             }
-          }
-          return child
-        })
+            return child
+          })
 
         return (
           <FieldContext.Provider value={field}>

--- a/packages/remix-forms/src/index.ts
+++ b/packages/remix-forms/src/index.ts
@@ -1,4 +1,5 @@
 export { createForm } from './createForm'
+export { useField } from './createField'
 export { createFormAction, performMutation } from './mutations'
 
 export type {


### PR DESCRIPTION
This hook can be used in any of the custom components, allowing those to change styling/behavior etc depending on the field's state. This is mostly useful for things like the required/error/dirty indicators (e.g. https://remix-forms.seasoned.cc/examples/render-field/required-indicator) which currently require the use of the `renderField` prop. See also #124.

Using the prop makes things quite verbose because the structure of each field will have to be replicated, even if just a single component needs to be customized. Since the default structure is not the same for all field types, customizing components in this way requires some gnarly copy and paste from the package's source code (see https://remix-forms.seasoned.cc/examples/render-field/inline-checkboxes).

For now, the PR only contains the code required to make `useField` work. If the maintainers agree with this approach, I'll add some examples to the docs as well (perhaps even replacing the current `renderField` section?), and tests where applicable.