### PR TITLE
Imperative submit

### DIFF
--- a/apps/web/app/routes/examples.tsx
+++ b/apps/web/app/routes/examples.tsx
@@ -100,6 +100,9 @@ export default function Component() {
           <SidebarLayout.NavLink to={'/examples/forms/multiple-forms'}>
             Multiple forms
           </SidebarLayout.NavLink>
+          <SidebarLayout.NavLink to={'/examples/forms/imperative-submit'}>
+            Imperative submit
+          </SidebarLayout.NavLink>
           <SidebarLayout.NavTitle>renderField</SidebarLayout.NavTitle>
           <SidebarLayout.NavLink
             to={'/examples/render-field/required-indicator'}

--- a/apps/web/app/routes/examples/forms/imperative-submit.tsx
+++ b/apps/web/app/routes/examples/forms/imperative-submit.tsx
@@ -1,0 +1,70 @@
+import hljs from 'highlight.js/lib/common'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
+import { formAction } from '~/formAction'
+import { z } from 'zod'
+import Form from '~/ui/form'
+import { metaTags } from '~/helpers'
+import { makeDomainFunction } from 'domain-functions'
+import Example from '~/ui/example'
+
+const title = 'Imperative submit'
+const description =
+  'In this example, we trigger a submit as soon as the user enters 4 characters.'
+
+export const meta: MetaFunction = () => metaTags({ title, description })
+
+const code = `const schema = z.object({ token: z.string().length(4) })
+
+export default () => (
+  <Form schema={schema}>
+    {({ Field, Errors, submit }) => (
+      <>
+        <Field
+          name="token"
+          onChange={(ev: React.ChangeEvent<HTMLInputElement>) => {
+            if (ev.target.value.length === 4) submit()
+          }}
+        />
+        <Errors />
+      </>
+    )}
+  </Form>
+)`
+
+const schema = z.object({
+  token: z.string().length(4),
+})
+
+export const loader: LoaderFunction = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = makeDomainFunction(schema)(async (values) => values)
+
+export const action: ActionFunction = async ({ request }) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <Form schema={schema}>
+        {({ Field, Errors, submit }) => (
+          <>
+            <Field
+              name="token"
+              placeholder="Type 4 digits"
+              onChange={(ev: React.ChangeEvent<HTMLInputElement>) => {
+                if (ev.target.value.length === 4) submit()
+              }}
+            />
+            <Errors />
+          </>
+        )}
+      </Form>
+    </Example>
+  )
+}

--- a/apps/web/tests/examples/forms/imperative-submit.spec.ts
+++ b/apps/web/tests/examples/forms/imperative-submit.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from '@playwright/test'
+import { test } from 'tests/setup/tests'
+
+const route = '/examples/forms/imperative-submit'
+
+test('With JS enabled', async ({ example }) => {
+  const { page } = example
+  const token = example.field('token')
+
+  await page.goto(route)
+
+  await token.input.first().type('123')
+  expect(page.locator('#action-data > pre')).toBeHidden()
+
+  await token.input.first().type('4')
+
+  await example.expectData({
+    token: '1234',
+  })
+})


### PR DESCRIPTION
This has been a requested feature lately. It allows for calling the form submit as a side effect of another action.
There are a few use cases described in #17 .

I added an example and tests based on a recent project where I felt the need for this feature.

The solution was inspired by @paulm17 's workaround.