### PR TITLE
Add missing fetcher reset test

### DIFF
--- a/apps/web/app/routes/examples/use-fetcher.spec.ts
+++ b/apps/web/app/routes/examples/use-fetcher.spec.ts
@@ -24,6 +24,7 @@ test('With JS enabled', async ({ example }) => {
   await button.click()
   await example.expectValid(name)
   await expect(name.input).toBeFocused()
+  await expect(name.input).toHaveValue('')
   await expect(page.locator('label[for=todo]')).toHaveText('todo')
 })
 


### PR DESCRIPTION
## Summary
- ensure the useFetcher example clears the field after submit

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: Example.expectData could not read action-data when running Playwright)*