### PR TITLE
Add missing form tests

### DIFF
--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -216,6 +216,26 @@ describe('createField', () => {
     expect(html).toContain('id="choice-b"')
     expect(html).toContain('for="choice-b"')
   })
+
+  it('creates radio inputs with fieldset and linked labels by default', () => {
+    const html = renderToStaticMarkup(
+      <ChoiceField
+        name="choice"
+        label="Choice"
+        radio
+        options={[
+          { name: 'A', value: 'a' },
+          { name: 'B', value: 'b' },
+        ]}
+      />
+    )
+
+    expect(html).toContain('<fieldset')
+    expect(html).toContain('id="choice-a"')
+    expect(html).toContain('for="choice-a"')
+    expect(html).toContain('id="choice-b"')
+    expect(html).toContain('for="choice-b"')
+  })
 })
 
 describe('component mappings', () => {

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -212,6 +212,21 @@ describe('SchemaForm', () => {
     expect(html).toMatch(/<input[^>]*autofocus[^>]*name="second"/)
   })
 
+  it('prefers error autofocus over autoFocus prop', () => {
+    const schema = z.object({ first: z.string(), second: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        errors={{ first: ['Required'] }}
+        autoFocus="second"
+      />
+    )
+
+    expect(html).toMatch(/<input[^>]*autofocus[^>]*name="first"/)
+    expect(html).not.toMatch(/<input[^>]*name="second"[^>]*autofocus/)
+  })
+
   it('displays global errors using Errors and Error components', () => {
     const schema = z.object({ name: z.string() })
 


### PR DESCRIPTION
## Summary
- test default radio markup in `createField`
- test autofocus priority when errors present

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run --workspace packages/remix-forms test`
- `CI=1 npm run test` *(fails: 2 Playwright tests, example app)*