### PR TITLE
Fix e2e test flakiness

### DIFF
--- a/apps/web/app/routes/examples/auto-generated.spec.ts
+++ b/apps/web/app/routes/examples/auto-generated.spec.ts
@@ -51,7 +51,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(howDidYouFindUs)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({
     firstName: 'John',

--- a/apps/web/app/routes/examples/context.spec.ts
+++ b/apps/web/app/routes/examples/context.spec.ts
@@ -31,7 +31,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await expect(page.locator('form > div[role="alert"]:visible')).toHaveText(
     'Missing custom header'
@@ -40,7 +40,7 @@ test('With JS enabled', async ({ example }) => {
   // Submit with valid headers
   await page.setExtraHTTPHeaders({ customHeader: 'foo' })
 
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({ email: 'john@doe.com' })
 })

--- a/apps/web/app/routes/examples/custom-input.spec.ts
+++ b/apps/web/app/routes/examples/custom-input.spec.ts
@@ -47,7 +47,7 @@ test('With JS enabled', async ({ example }) => {
   await email.input.fill('john@doe.com')
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({ firstName: 'John', email: 'john@doe.com' })
 })

--- a/apps/web/app/routes/examples/custom-response.spec.ts
+++ b/apps/web/app/routes/examples/custom-response.spec.ts
@@ -41,7 +41,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   const actionData = JSON.parse(

--- a/apps/web/app/routes/examples/edit-values.spec.ts
+++ b/apps/web/app/routes/examples/edit-values.spec.ts
@@ -23,7 +23,7 @@ test('With JS enabled', async ({ example }) => {
   await expect(button).toBeEnabled()
 
   // Submit form
-  button.click()
+  await button.click()
 
   await example.expectData({
     firstName: 'Mary',

--- a/apps/web/app/routes/examples/error-indicator.spec.ts
+++ b/apps/web/app/routes/examples/error-indicator.spec.ts
@@ -59,7 +59,7 @@ test('With JS enabled', async ({ example }) => {
   await expect(firstName.input).toHaveClass(validClass)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   await example.expectData({

--- a/apps/web/app/routes/examples/field-error.spec.ts
+++ b/apps/web/app/routes/examples/field-error.spec.ts
@@ -20,7 +20,7 @@ test('With JS enabled clear server error on the client', async ({
   await example.expectValid(password)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   // Show field error
@@ -72,7 +72,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(password)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   // Show field error
@@ -80,7 +80,7 @@ test('With JS enabled', async ({ example }) => {
 
   // Submit valid form
   await email.input.fill('john@doe.com')
-  button.click()
+  await button.click()
   await example.expectData({ email: 'john@doe.com', password: '123456' })
 })
 

--- a/apps/web/app/routes/examples/field-with-children.spec.ts
+++ b/apps/web/app/routes/examples/field-with-children.spec.ts
@@ -45,7 +45,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({ firstName: 'John', email: 'john@doe.com' })
 })

--- a/apps/web/app/routes/examples/form-with-children.spec.ts
+++ b/apps/web/app/routes/examples/form-with-children.spec.ts
@@ -69,7 +69,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   await example.expectData({

--- a/apps/web/app/routes/examples/hidden-field.spec.ts
+++ b/apps/web/app/routes/examples/hidden-field.spec.ts
@@ -51,7 +51,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(howDidYouFindUs)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({
     csrfToken: 'abc123',

--- a/apps/web/app/routes/examples/inline-checkboxes.spec.ts
+++ b/apps/web/app/routes/examples/inline-checkboxes.spec.ts
@@ -52,7 +52,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(newsletter)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   await example.expectData({

--- a/apps/web/app/routes/examples/on-blur.spec.ts
+++ b/apps/web/app/routes/examples/on-blur.spec.ts
@@ -44,7 +44,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({ firstName: 'John', email: 'john@doe.com' })
 })

--- a/apps/web/app/routes/examples/on-submit.spec.ts
+++ b/apps/web/app/routes/examples/on-submit.spec.ts
@@ -41,7 +41,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({ firstName: 'John', email: 'john@doe.com' })
 })

--- a/apps/web/app/routes/examples/redirect.spec.ts
+++ b/apps/web/app/routes/examples/redirect.spec.ts
@@ -42,7 +42,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await expect(page).toHaveURL(/\/success\/?$/)
 })

--- a/apps/web/app/routes/examples/required-indicator.spec.ts
+++ b/apps/web/app/routes/examples/required-indicator.spec.ts
@@ -48,7 +48,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(newsletter)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   await example.expectData({

--- a/apps/web/app/routes/examples/transform-values.spec.ts
+++ b/apps/web/app/routes/examples/transform-values.spec.ts
@@ -41,7 +41,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
 
   await example.expectData({

--- a/apps/web/app/routes/examples/without-redirect.spec.ts
+++ b/apps/web/app/routes/examples/without-redirect.spec.ts
@@ -41,7 +41,7 @@ test('With JS enabled', async ({ example }) => {
   await example.expectValid(email)
 
   // Submit form
-  button.click()
+  await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({ firstName: 'John', email: 'john@doe.com' })
 })

--- a/apps/web/tests/setup/example.ts
+++ b/apps/web/tests/setup/example.ts
@@ -87,7 +87,7 @@ class Example {
     radioName: string,
     options: { name: string; value: string }[]
   ) {
-    Promise.all(
+    await Promise.all(
       options.map(({ value }) =>
         expect(
           this.page.locator(`[name="${radioName}"][value="${value}"]:visible`)


### PR DESCRIPTION
## Summary
- await every button click in Playwright specs
- wait for radio option checks in test helpers

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test`
