### PR TITLE
Add ZodPipeline support

### DIFF
--- a/packages/remix-forms/src/prelude.test.ts
+++ b/packages/remix-forms/src/prelude.test.ts
@@ -13,6 +13,12 @@ describe('objectFromSchema', () => {
     const schema = z.preprocess((v) => v, inner)
     expect(objectFromSchema(schema)).toBe(inner)
   })
+
+  it('unwraps Zod pipelines to return the inner object', () => {
+    const inner = z.object({ done: z.boolean() })
+    const schema = z.object({}).pipe(inner)
+    expect(objectFromSchema(schema)).toBe(inner)
+  })
 })
 
 describe('mapObject', () => {

--- a/packages/remix-forms/src/shape-info.test.ts
+++ b/packages/remix-forms/src/shape-info.test.ts
@@ -55,6 +55,14 @@ describe('shapeInfo', () => {
     expect(info.getDefaultValue?.()).toBe('bar')
   })
 
+  it('unwraps pipelines', () => {
+    const shape = z.string().pipe(z.number()).optional()
+    const info = shapeInfo(shape)
+    expect(info.typeName).toBe('ZodNumber')
+    expect(info.optional).toBe(true)
+    expect(info.nullable).toBe(false)
+  })
+
   it('returns enum values', () => {
     const info = shapeInfo(z.enum(['a', 'b']))
     expect(info).toEqual({

--- a/packages/remix-forms/src/shape-info.ts
+++ b/packages/remix-forms/src/shape-info.ts
@@ -40,6 +40,10 @@ function shapeInfo(
     )
   }
 
+  if (typeName === 'ZodPipeline') {
+    return shapeInfo(def.out, optional, nullable, getDefaultValue, enumValues)
+  }
+
   if (typeName === 'ZodOptional') {
     return shapeInfo(def.innerType, true, nullable, getDefaultValue, enumValues)
   }


### PR DESCRIPTION
## Summary
- expand supported schema modifiers to include `ZodPipeline`
- recurse through pipelines when extracting inner objects
- handle pipelines in `shapeInfo`
- test pipeline behaviour for `objectFromSchema` and `shapeInfo`

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc` *(fails: error occurred in dts build)*
- `npm run test` *(fails: 7 test files failed)*