### PR TITLE
Upgrade coerce-form-data to v2.0.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@react-router/node": "7.13.1",
     "@react-router/serve": "7.13.1",
     "@tailwindcss/forms": "0.5.10",
+    "coerce-form-data": "^2.0.0",
     "composable-functions": "^4.5.0",
     "cross-env": "^7.0.3",
     "highlight.js": "^11.11.1",

--- a/packages/remix-forms/package.json
+++ b/packages/remix-forms/package.json
@@ -32,7 +32,7 @@
   ],
   "author": "Daniel Weinmann",
   "peerDependencies": {
-    "coerce-form-data": ">=1",
+    "coerce-form-data": ">=2",
     "composable-functions": ">=4",
     "react": ">=16.8",
     "react-hook-form": ">=7.27",
@@ -40,7 +40,7 @@
     "zod": ">=4.0.0"
   },
   "devDependencies": {
-    "coerce-form-data": "1.1.0",
+    "coerce-form-data": "2.0.0",
     "@types/react": ">=16.8",
     "@types/react-dom": ">=16.8",
     "react": ">=16.8",

--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -75,7 +75,7 @@ describe('useField', () => {
         name="foo"
         label="Foo"
         fieldType="date"
-        value={new Date('2024-05-06')}
+        value={new Date(2024, 4, 6)}
       >
         {() => <ValueReader />}
       </Field>
@@ -137,13 +137,31 @@ describe('createField', () => {
     expect(setValueAs('5')).toBe(5)
   })
 
+  it('returns null from setValueAs when coercion fails', () => {
+    const schema = z.object({ amount: z.number() })
+    const NumField = createField<typeof schema>({ register })
+
+    renderToStaticMarkup(
+      <NumField
+        name="amount"
+        label="Amount"
+        fieldType="number"
+        shape={schema.shape.amount}
+      />
+    )
+
+    const [, options] = (register as unknown as Mock).mock.calls[0]
+    const { setValueAs } = options as { setValueAs: (v: unknown) => unknown }
+    expect(setValueAs('')).toBeNull()
+  })
+
   it('formats Date values for date fields', () => {
     const html = renderToStaticMarkup(
       <Field
         name="foo"
         label="Foo"
         fieldType="date"
-        value={new Date('2024-01-02')}
+        value={new Date(2024, 0, 2)}
       />
     )
     expect(html).toContain('value="2024-01-02"')

--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -1,4 +1,4 @@
-import { coerceValue, parseDate } from 'coerce-form-data'
+import { FormDataCoercionError, coerceValue, parseDate } from 'coerce-form-data'
 import * as React from 'react'
 import type { UseFormRegister, UseFormRegisterReturn } from 'react-hook-form'
 import type { z } from 'zod'
@@ -355,8 +355,14 @@ function createField<Schema extends AnyZodObject>({
       const type = typeProp ?? getInputType(fieldType, radio)
 
       const { ref: registerRef, ...registerProps } = register(String(name), {
-        setValueAs: (value) =>
-          coerceValue(value, toFieldDescriptor(shapeInfo(shape))),
+        setValueAs: (value) => {
+          try {
+            return coerceValue(value, toFieldDescriptor(shapeInfo(shape)))
+          } catch (error) {
+            if (error instanceof FormDataCoercionError) return null
+            throw error
+          }
+        },
       })
 
       const labelId = `label-for-${name.toString()}`

--- a/packages/remix-forms/src/internal-mutations.test.ts
+++ b/packages/remix-forms/src/internal-mutations.test.ts
@@ -54,6 +54,16 @@ describe('getFormValues', () => {
     })
   })
 
+  it('returns null for required fields with empty values', async () => {
+    const schema = z.object({
+      count: z.number(),
+      day: z.date(),
+    })
+    const request = makeRequest(new URLSearchParams())
+    const values = await getFormValues(request, schema)
+    expect(values).toEqual({ count: null, day: null })
+  })
+
   it('defaults optional and nullable fields when missing', async () => {
     const schema = z.object({
       opt: z.string().optional(),

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -1,5 +1,5 @@
 import type { FormValue } from 'coerce-form-data'
-import { coerceValue } from 'coerce-form-data'
+import { FormDataCoercionError, coerceValue } from 'coerce-form-data'
 import type { ComposableWithSchema } from 'composable-functions'
 import {
   type InputError,
@@ -184,10 +184,18 @@ async function getFormValues<Schema extends FormSchema>(
   const values: FormValues<z.infer<Schema>> = {}
   for (const key in shape) {
     const value = input[key]
-    values[key as keyof z.infer<Schema>] = coerceValue(
-      value as FormValue,
-      toFieldDescriptor(shapeInfo(shape[key]))
-    )
+    try {
+      values[key as keyof z.infer<Schema>] = coerceValue(
+        value as FormValue,
+        toFieldDescriptor(shapeInfo(shape[key]))
+      )
+    } catch (error) {
+      if (error instanceof FormDataCoercionError) {
+        values[key as keyof z.infer<Schema>] = null
+      } else {
+        throw error
+      }
+    }
   }
 
   return values

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -34,7 +34,7 @@ describe('SchemaForm', () => {
         values={{
           agree: true,
           amount: 5,
-          day: new Date('2024-05-06'),
+          day: new Date(2024, 4, 6),
         }}
       />
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tailwindcss/forms':
         specifier: 0.5.10
         version: 0.5.10(tailwindcss@3.4.17)
+      coerce-form-data:
+        specifier: ^2.0.0
+        version: 2.0.0
       composable-functions:
         specifier: ^4.5.0
         version: 4.5.0
@@ -134,8 +137,8 @@ importers:
         specifier: '>=16.8'
         version: 18.3.6(@types/react@18.3.20)
       coerce-form-data:
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 2.0.0
+        version: 2.0.0
       react:
         specifier: '>=16.8'
         version: 18.3.1
@@ -1338,8 +1341,8 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  coerce-form-data@1.1.0:
-    resolution: {integrity: sha512-f6MQutBbr3f9ZwPD1fzOYXpeZ3ZDng/SCZDQuUIk5amx4d39RK6vUf06cGu0MuKWPHIv8u8mIaK+TZcok9kJDw==}
+  coerce-form-data@2.0.0:
+    resolution: {integrity: sha512-tO0Hqt5S76S2SgMKKTIQmvULbZD2Ygx8opJFWuhsuTl/qQigYXVpmoyWtbL6AjpoLesqlP3EN0Xf/qcG8FzHVg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3354,7 +3357,7 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  coerce-form-data@1.1.0: {}
+  coerce-form-data@2.0.0: {}
 
   commander@4.1.1: {}
 


### PR DESCRIPTION
## Summary
- Bump `coerce-form-data` from 1.1.0 to 2.0.0 (peer dep `>=2`, dev dep `2.0.0`)
- Add `coerce-form-data` as explicit dependency in the web app
- Handle `FormDataCoercionError` in `getFormValues` and `setValueAs` by falling back to `null` (preserves Zod validation error messages like `"Invalid input: expected number, received null"`)
- Fix date tests to use local-time constructors (`new Date(2024, 4, 6)`) to match v2's `parseDate` behavior

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run tsc` passes
- [x] `pnpm run test` — all 199 unit tests pass
- [ ] `pnpm run test` (E2E) — verify numbers/dates with-js and without-js specs still pass