### PR TITLE
Redesign website with dark red theme

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,9 +1,8 @@
 import 'highlight.js/styles/a11y-dark.css'
-import type { LinksFunction, UIMatch } from 'react-router'
+import type { LinksFunction } from 'react-router'
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
 import { config } from 'zod'
 import en from 'zod/v4/locales/en.js'
-import type { Route } from './+types/root'
 import favicon from './favicon.png'
 import seasonedIconDark from './seasoned-icon-dark.webp'
 import seasonedIconLight from './seasoned-icon-light.webp'
@@ -14,35 +13,38 @@ import TopBar from './ui/top-bar'
 
 config(en())
 
-export const links: LinksFunction = () => {
-  return [{ rel: 'icon', href: favicon, type: 'image/png' }]
-}
+export const links: LinksFunction = () => [
+  { rel: 'icon', href: favicon, type: 'image/png' },
+  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+  {
+    rel: 'preconnect',
+    href: 'https://fonts.gstatic.com',
+    crossOrigin: 'anonymous',
+  },
+  {
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap',
+  },
+]
 
-export default function App({ matches }: Route.ComponentProps) {
-  const match = matches.find(
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    (match) => match?.handle && 'topBar' in (match.handle as any)
-  ) as UIMatch<unknown, { topBar: React.ReactNode }>
-  const secondTopBar = match?.handle.topBar || null
-
+export default function App() {
   return (
-    <html lang="en" className="h-full overflow-x-hidden bg-base-200">
+    <html lang="en" data-theme="dark" className="h-full overflow-x-hidden">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
       </head>
-      <body className="flex min-h-screen w-screen max-w-[100vw] flex-col overflow-y-auto overflow-x-hidden bg-base-200 text-base-content antialiased">
+      <body className="flex min-h-screen w-screen max-w-[100vw] flex-col overflow-y-auto overflow-x-hidden bg-base-100 text-base-content antialiased">
         <GlobalLoading />
         <TopBar />
-        {secondTopBar}
-        <main className="flex flex-1 flex-col">
+        <main className="flex flex-1 flex-col pt-14">
           <Outlet />
         </main>
-        <footer className="flex justify-center bg-base-100 p-4">
+        <footer className="flex justify-center border-white/5 border-t bg-base-100 p-8">
           <a
-            href="https://seasoned.cc"
+            href="https://www.seasoned.cc"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-4"

--- a/apps/web/app/routes/get-started.spec.ts
+++ b/apps/web/app/routes/get-started.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from 'tests/setup/tests'
 
 const route = '/get-started'
 
-test('Get Started page shows installation info', async ({ example }) => {
+test('Get started page shows installation info', async ({ example }) => {
   const { page } = example
 
   await page.goto(route)
 
-  await expect(page.locator('h1')).toHaveText('Get Started')
+  await expect(page.locator('h1')).toHaveText('Get started')
   await expect(
     page.getByRole('link', { name: 'Check out more examples' })
   ).toHaveAttribute('href', '/examples')

--- a/apps/web/app/routes/get-started.tsx
+++ b/apps/web/app/routes/get-started.tsx
@@ -9,7 +9,7 @@ import Pre from '~/ui/pre'
 import SubHeading from '~/ui/sub-heading'
 import type { Route } from './+types/get-started'
 
-const title = 'Get Started'
+const title = 'Get started'
 const description = 'The full-stack form library for React Router v7'
 
 export const meta: Route.MetaFunction = () => metaTags({ title, description })
@@ -145,7 +145,7 @@ export default function Component({ loaderData }: Route.ComponentProps) {
   return (
     <div className="relative m-auto flex max-w-2xl flex-col gap-8 px-4 py-8 sm:px-8 sm:py-16">
       <div className="flex items-center justify-between gap-4">
-        <Heading>Get Started</Heading>
+        <Heading>Get started</Heading>
         <CopyPageButton />
       </div>
       <SubHeading>Installation</SubHeading>

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -11,16 +11,13 @@ import {
 import { Link } from 'react-router'
 import { formAction } from 'remix-forms'
 import { z } from 'zod'
-import { metaTags } from '~/helpers'
+import { cx, metaTags } from '~/helpers'
 import Code from '~/ui/code'
 import ExternalLink from '~/ui/external-link'
-import Feature from '~/ui/feature'
-import Heading from '~/ui/heading'
 import { SchemaForm } from '~/ui/schema-form'
 import type { Route } from './+types/home'
 
-const title = 'The full-stack form library for React Router v7'
-
+const title = 'Full-stack forms for React Router'
 const description =
   'E2E type-safe, with client + server validations, a11y, pending UI, and focus management'
 
@@ -68,92 +65,185 @@ export const action = async ({ request }: Route.ActionArgs) =>
     successPath: '/success',
   })
 
+const iconGradients = [
+  'from-primary/20',
+  'from-secondary/20',
+  'from-accent/20',
+] as const
+
+const features = [
+  {
+    icon: FlaskConical,
+    title: '100% customizable UI',
+    desc: 'Customize everything without losing our accessible defaults.',
+  },
+  {
+    icon: Scale,
+    title: 'Single source of truth',
+    desc: 'Write your schema once and derive everything else from it.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Bulletproof DX',
+    desc: 'End-to-end typed to your schema. Goodbye typos, hello autocomplete!',
+  },
+  {
+    icon: Cloud,
+    title: 'Server-side wiring',
+    desc: 'Perform secure server-side mutations with zero boilerplate.',
+  },
+  {
+    icon: ClipboardCheck,
+    title: 'Full-stack validation',
+    desc: 'Validate everything both on the client and the server.',
+  },
+  {
+    icon: MousePointerClick,
+    title: 'Focus management',
+    desc: 'Focus on the first field with error even for server-side failures.',
+  },
+]
+
+type GlassCardProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+function GlassCard({ children, className }: GlassCardProps) {
+  return (
+    <div
+      className={cx(
+        'rounded-2xl border border-white/10 bg-white/5 p-6',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
 export default function Component({ loaderData }: Route.ComponentProps) {
   const { code } = loaderData
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-8 sm:py-16">
-      <div className="flex flex-col gap-8 sm:gap-16">
-        <Heading className="text-center">
-          The full-stack form library
-          <br />
-          for React Router v7
-        </Heading>
-        <div className="flex flex-col gap-6 xl:flex-row">
-          <Code>{code}</Code>
-          <div className="xl:flex-1">
-            <h3 className="pb-6 text-center text-base-content/60 text-lg">
-              This tiny code creates the form below 👇🏽
-            </h3>
-            <h2 className="pb-6 text-center text-base-content text-xl md:text-3xl">
-              E2E{' '}
-              <span className="underline decoration-green-500">type-safe</span>,
-              with client + server{' '}
-              <span className="underline decoration-purple-500">
-                validations
-              </span>
-              , <span className="underline decoration-orange-500">a11y</span>,{' '}
-              <span className="underline decoration-blue-500">pending UI</span>,
-              and{' '}
-              <span className="underline decoration-yellow-500">
-                focus management
-              </span>
-            </h2>
-            <SchemaForm schema={schema}>
-              {({ Field, Errors, Button }) => (
-                <>
-                  <Field name="firstName" />
-                  <Field name="email" />
-                  <Field name="howDidYouFindUs" />
-                  <Errors />
-                  <div className="flex items-center gap-4">
-                    <h4 className="flex-1 text-center text-base-content/60">
-                      (Go ahead, try it with JS disabled as well 😉)
-                    </h4>
-                    <Button />
-                  </div>
-                </>
-              )}
-            </SchemaForm>
+    <>
+      <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden sm:min-h-[80vh]">
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse at 20% 50%, rgba(167,139,250,0.15) 0%, transparent 50%), radial-gradient(ellipse at 80% 50%, rgba(34,211,238,0.15) 0%, transparent 50%), radial-gradient(ellipse at 50% 100%, rgba(244,114,182,0.1) 0%, transparent 50%)',
+          }}
+        />
+        <div className="relative mx-auto max-w-5xl px-4 text-center">
+          <h1 className="mb-6 font-bold font-display text-4xl leading-none tracking-tighter sm:text-5xl md:text-8xl">
+            <span className="bg-linear-to-r from-[#c0392b] via-[#ff7979] to-[#e74c3c] bg-clip-text text-transparent">
+              Full-stack forms
+            </span>
+            <br />
+            <span className="text-base-content">for React Router</span>
+          </h1>
+          <p className="mx-auto mb-10 max-w-2xl text-base-content/60 text-lg sm:text-xl">
+            E2E type-safe, with client + server validations, a11y, pending UI,
+            and focus management
+          </p>
+          <div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
+            <Link
+              to="/get-started"
+              className="btn btn-lg border-0 bg-linear-to-r from-[#c0392b] via-[#e04848] to-[#e74c3c] text-primary-content shadow-lg shadow-primary/25 transition-shadow hover:shadow-primary/30 hover:shadow-xl"
+            >
+              Get started
+            </Link>
+            <Link
+              to="/examples"
+              className="btn btn-outline btn-lg border-white/20"
+            >
+              Examples
+            </Link>
           </div>
         </div>
-        <div className="flex flex-col items-center gap-3">
-          <p className="text-center text-base-content text-xl sm:text-2xl">
-            Works with Zod, Yup, Valibot, ArkType, Effect Schema, and Joi
-          </p>
-          <p className="text-base-content/60 text-sm">
-            Powered by{' '}
-            <ExternalLink href="https://standardschema.dev">
-              Standard Schema
-            </ExternalLink>
-          </p>
+      </section>
+
+      <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-8 sm:py-24">
+        <div className="flex flex-col gap-8 xl:flex-row">
+          <div className="xl:flex-1">
+            <Code>{code}</Code>
+          </div>
+          <div className="xl:flex-1">
+            <GlassCard className="backdrop-blur-md">
+              <h3 className="pb-6 text-center text-base-content/50">
+                This tiny code creates the form below 👇🏽
+              </h3>
+              <SchemaForm schema={schema}>
+                {({ Field, Errors, Button }) => (
+                  <>
+                    <Field name="firstName" />
+                    <Field name="email" />
+                    <Field name="howDidYouFindUs" />
+                    <Errors />
+                    <div className="flex items-center gap-4">
+                      <p className="flex-1 text-center text-base-content/40 text-sm">
+                        (Go ahead, try it with JS disabled as well 😉)
+                      </p>
+                      <Button />
+                    </div>
+                  </>
+                )}
+              </SchemaForm>
+            </GlassCard>
+          </div>
         </div>
-        <dl className="grid auto-rows-min gap-8 md:grid-cols-2 xl:grid-cols-3">
-          <Feature icon={FlaskConical} title="100% customizable UI">
-            Customize everything without losing our accessible defaults.
-          </Feature>
-          <Feature icon={Scale} title="Single source of truth">
-            Write your schema once and derive everything else from it.
-          </Feature>
-          <Feature icon={ShieldCheck} title="Bulletproof DX">
-            End-to-end typed to your schema. Goodbye typos, hello autocomplete!
-          </Feature>
-          <Feature icon={Cloud} title="Server-side wiring">
-            Perform secure server-side mutations with zero boilerplate.
-          </Feature>
-          <Feature icon={ClipboardCheck} title="Full-stack validation">
-            Validate everything both on the client and the server.
-          </Feature>
-          <Feature icon={MousePointerClick} title="Focus management">
-            Focus on the first field with error even for server-side failures.
-          </Feature>
+      </section>
+
+      <section className="mx-auto w-full max-w-7xl px-4 pt-16 pb-8 sm:px-8">
+        <h2 className="mb-4 text-center font-bold font-display text-3xl tracking-tighter sm:text-4xl">
+          <span className="bg-linear-to-r from-[#c0392b] via-[#ff7979] to-[#e74c3c] bg-clip-text text-transparent">
+            From schema to form
+          </span>
+        </h2>
+        <p className="mb-12 text-center text-base-content/50">
+          Works with Zod, Yup, Valibot, ArkType, Effect Schema, and Joi. Powered
+          by{' '}
+          <ExternalLink
+            href="https://standardschema.dev"
+            className="text-secondary"
+          >
+            Standard Schema
+          </ExternalLink>
+          .
+        </p>
+        <dl className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {features.map(({ icon: Icon, title, desc }, i) => (
+            <GlassCard key={title}>
+              <dt className="flex items-center gap-3">
+                <div
+                  className={cx(
+                    'flex size-10 items-center justify-center rounded-xl bg-linear-to-br to-transparent',
+                    iconGradients[i % iconGradients.length]
+                  )}
+                >
+                  <Icon className="size-5 text-primary" aria-hidden="true" />
+                </div>
+                <span className="font-display font-semibold text-base-content tracking-tighter">
+                  {title}
+                </span>
+              </dt>
+              <dd className="mt-3 text-base-content/60 leading-relaxed">
+                {desc}
+              </dd>
+            </GlassCard>
+          ))}
         </dl>
-        <div className="flex justify-center">
-          <Link to="/get-started" className="btn btn-primary">
-            Get Started
-          </Link>
-        </div>
-      </div>
-    </div>
+      </section>
+
+      <section className="flex justify-center px-4 pt-8 pb-16 sm:pt-12 sm:pb-24">
+        <Link
+          to="/get-started"
+          className="btn btn-lg border-0 bg-linear-to-r from-[#c0392b] via-[#e04848] to-[#e74c3c] text-primary-content shadow-lg shadow-primary/25"
+        >
+          Start building
+        </Link>
+      </section>
+    </>
   )
 }

--- a/apps/web/app/tailwind.css
+++ b/apps/web/app/tailwind.css
@@ -2,26 +2,41 @@
 @plugin "daisyui";
 
 @plugin "daisyui/theme" {
-  name: "light";
-  default: true;
-  --color-primary: #ec4899;
-  --color-primary-content: #ffffff;
-  --depth: 0;
-}
-
-@plugin "daisyui/theme" {
   name: "dark";
-  prefersdark: true;
-  --color-primary: #ec4899;
-  --color-primary-content: #ffffff;
-  --color-base-100: #0e151d;
-  --color-base-200: #1a2230;
-  --color-base-300: #2a3240;
-  --color-base-content: #e4e7ea;
+  default: true;
+  color-scheme: dark;
+  --color-base-100: #0c0c1d;
+  --color-base-200: #141428;
+  --color-base-300: #1e1e3a;
+  --color-base-content: #e8e8f0;
+  --color-primary: #e04444;
+  --color-primary-content: #e8e8f0;
+  --color-secondary: #e04848;
+  --color-secondary-content: #0c0c1d;
+  --color-accent: #e74c3c;
+  --color-accent-content: #0c0c1d;
+  --color-neutral: #2a2a4a;
+  --color-neutral-content: #e8e8f0;
+  --color-info: #38bdf8;
+  --color-info-content: #0c0c1d;
+  --color-success: #34d399;
+  --color-success-content: #0c0c1d;
+  --color-warning: #fbbf24;
+  --color-warning-content: #0c0c1d;
+  --color-error: #f87171;
+  --color-error-content: #0c0c1d;
+  --radius-selector: 1.5rem;
+  --radius-field: 1rem;
+  --radius-box: 1.5rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
   --depth: 0;
+  --noise: 0;
 }
 
 @theme {
   --font-sans: "Inter", "ui-sans-serif", "system-ui", "sans-serif",
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-display: "Space Grotesk", "sans-serif";
 }

--- a/apps/web/app/ui/example.tsx
+++ b/apps/web/app/ui/example.tsx
@@ -54,13 +54,14 @@ export default function Example({
       </div>
       <div className="flex flex-col gap-6 xl:flex-row">
         <Code>{code}</Code>
-        <div className="xl:flex-1">{children}</div>
+        <div className="self-start rounded-2xl border border-white/10 bg-white/5 p-6 xl:flex-1">
+          {children}
+        </div>
       </div>
       {data ? (
         <div
           id="action-data"
-          data-theme="dark"
-          className="flex flex-col gap-4 rounded bg-base-100 p-2"
+          className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-4"
         >
           <h4>
             This data was returned by our <em>action</em>. We got it through the{' '}

--- a/apps/web/app/ui/heading.tsx
+++ b/apps/web/app/ui/heading.tsx
@@ -8,7 +8,7 @@ export default function Heading({
     <h1
       {...props}
       className={cx(
-        'font-bold text-2xl text-primary leading-7 sm:text-5xl sm:leading-none',
+        'font-bold text-2xl text-primary leading-7 tracking-tight sm:text-5xl sm:leading-none',
         className
       )}
     />

--- a/apps/web/app/ui/nav-link.tsx
+++ b/apps/web/app/ui/nav-link.tsx
@@ -7,7 +7,7 @@ export default function NavLink({ className, ...props }: NavLinkProps) {
     <RRNavLink
       className={({ isActive }) =>
         cx(
-          'btn btn-sm w-full justify-start',
+          'btn btn-sm w-full justify-start rounded',
           isActive ? 'btn-primary' : 'btn-ghost',
           typeof className === 'function'
             ? className({ isActive, isPending: false, isTransitioning: false })

--- a/apps/web/app/ui/pre.tsx
+++ b/apps/web/app/ui/pre.tsx
@@ -6,10 +6,9 @@ export default function Pre({
 }: JSX.IntrinsicElements['pre']) {
   return (
     <pre
-      data-theme="dark"
       {...props}
       className={cx(
-        'max-w-[calc(100vw-2rem)] overflow-auto rounded bg-base-100 p-2 font-mono text-xs sm:text-sm',
+        'max-w-[calc(100vw-2rem)] overflow-auto rounded-2xl border border-white/10 bg-white/5 p-4 font-mono text-xs sm:text-sm',
         className
       )}
     />

--- a/apps/web/app/ui/sub-heading.tsx
+++ b/apps/web/app/ui/sub-heading.tsx
@@ -8,7 +8,7 @@ export default function SubHeading({
     <h2
       {...props}
       className={cx(
-        'font-medium text-base-content text-lg leading-6 sm:text-2xl sm:leading-snug',
+        'font-medium text-base-content text-lg leading-6 tracking-tight sm:text-2xl sm:leading-snug',
         className
       )}
     />

--- a/apps/web/app/ui/top-bar.tsx
+++ b/apps/web/app/ui/top-bar.tsx
@@ -1,62 +1,67 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Menu } from 'lucide-react'
 import { Link } from 'react-router'
-import logo from '~/logo.png'
 import ExternalLink from './external-link'
 import GitHub from './icons/github'
 
 const navigation = [
   { name: 'Home', to: '/' },
-  { name: 'Get Started', to: '/get-started' },
+  { name: 'Get started', to: '/get-started' },
   { name: 'Examples', to: '/examples' },
 ]
 
 export default function TopBar() {
   return (
-    <nav className="navbar sticky top-0 bg-base-100 p-4">
+    <nav className="navbar fixed top-0 z-50 border-white/5 border-b bg-base-100/60 px-4 backdrop-blur-xl">
       <div className="navbar-start">
-        <Link to="/" className="block size-10">
-          <img
-            src={logo}
-            alt="Remix Forms"
-            title="Remix Forms"
-            className="size-10"
-          />
+        <Link
+          to="/"
+          className="font-bold font-display text-lg tracking-tighter"
+        >
+          <span className="bg-linear-to-r from-[#c0392b] via-[#ff7979] to-[#e74c3c] bg-clip-text text-transparent">
+            Remix Forms
+          </span>
         </Link>
       </div>
       <div className="navbar-end gap-2 sm:gap-4">
-        <Link to="/get-started" className="btn btn-primary">
-          Get Started
+        <Link
+          to="/get-started"
+          className="btn btn-primary btn-sm border-0 bg-linear-to-r from-[#c0392b] via-[#e04848] to-[#e74c3c]"
+        >
+          Get started
         </Link>
-        <Link to="/examples" className="btn btn-outline hidden sm:inline-flex">
+        <Link
+          to="/examples"
+          className="btn btn-ghost btn-sm hidden sm:inline-flex"
+        >
           Examples
         </Link>
         <ExternalLink
           href="https://github.com/seasonedcc/remix-forms"
-          className="no-underline"
+          className="hidden text-base-content/50 no-underline transition-colors hover:text-base-content sm:block"
         >
-          <GitHub />
+          <GitHub className="size-5" />
         </ExternalLink>
         <div className="flex sm:hidden">
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
-              <button type="button" className="btn btn-ghost btn-square">
+              <button type="button" className="btn btn-ghost btn-square btn-sm">
                 <span className="sr-only">Open main menu</span>
-                <Menu className="block size-6" aria-hidden="true" />
+                <Menu className="block size-5" aria-hidden="true" />
               </button>
             </DropdownMenu.Trigger>
             <DropdownMenu.Portal>
               <DropdownMenu.Content
                 side="bottom"
                 sideOffset={5}
-                className="mr-2 flex flex-col gap-3 rounded bg-base-300 p-4"
+                className="z-50 mr-2 flex flex-col gap-3 rounded-xl border border-white/10 bg-base-200/95 p-4 backdrop-blur-xl"
               >
                 {navigation.map((item) => (
                   <DropdownMenu.Item key={item.name} asChild>
                     <Link to={item.to}>{item.name}</Link>
                   </DropdownMenu.Item>
                 ))}
-                <DropdownMenu.Separator className="h-px bg-base-content/30" />
+                <DropdownMenu.Separator className="h-px bg-white/10" />
                 <DropdownMenu.Item asChild>
                   <a
                     href="https://github.com/seasonedcc/remix-forms"

--- a/apps/web/styles/app.css
+++ b/apps/web/styles/app.css
@@ -32,6 +32,6 @@
   }
   h1,
   .h1 {
-    @apply text-2xl font-bold leading-7  sm:text-5xl  text-pink-500;
+    @apply text-2xl font-bold leading-7 sm:text-5xl text-primary;
   }
 }


### PR DESCRIPTION
## Summary

- Replace light/dark pink theme with a single dark-only red theme (primary `#e04444`, gradient accents `#c0392b` → `#ff7979` → `#e74c3c`)
- Redesign homepage with full-viewport hero, gradient text headings (Space Grotesk), glass-morphism code/form cards, and feature grid
- Redesign navbar with gradient logo text, backdrop blur, and glass-morphism mobile dropdown menu
- Update all shared UI components (Pre, Heading, SubHeading, Example, TopBar) to match the new dark glass card design system
- Normalize copy to sentence case throughout ("Get started", "Start building")
- Simplify root layout — dark-only with `data-theme="dark"`, no theme switching infrastructure

## Test plan

- [ ] Visit `/` — verify hero section, gradient headings, code demo, live form, feature grid, and CTA
- [ ] Visit `/get-started` — verify content renders with updated headings and code card styling
- [ ] Visit `/examples` — verify sidebar nav and example pages render with glass card form containers
- [ ] Test mobile — hamburger menu opens, hero buttons stack, layout doesn't overflow
- [ ] Submit the demo form — verify redirect to `/success`
- [ ] Run `pnpm run tsc`, `pnpm run lint`, `pnpm run test`