### PR TITLE
BREAKING: Flatten nested errors to dot-path keys

### DIFF
--- a/packages/remix-forms/src/internal-mutations.test.ts
+++ b/packages/remix-forms/src/internal-mutations.test.ts
@@ -8,7 +8,22 @@ function makeRequest(body: URLSearchParams) {
 }
 
 describe('errorMessagesForSchema', () => {
-  it('aggregates messages by path', () => {
+  it('returns flat keys for single-segment paths', () => {
+    const schema = z.object({ name: z.string(), age: z.number() })
+    const errors = [
+      new InputError('Required', ['name']),
+      new InputError('Invalid', ['age']),
+    ]
+
+    const result = errorMessagesForSchema(errors, schema)
+
+    expect(result).toEqual({
+      name: ['Required'],
+      age: ['Invalid'],
+    })
+  })
+
+  it('aggregates messages by dot-path', () => {
     const schema = z.object({
       user: z.object({ name: z.string(), age: z.number() }),
     })
@@ -22,8 +37,38 @@ describe('errorMessagesForSchema', () => {
     const result = errorMessagesForSchema(errors, schema)
 
     expect(result).toEqual({
-      user: { name: ['Required', 'Too short'], age: ['Invalid'] },
+      'user.name': ['Required', 'Too short'],
+      'user.age': ['Invalid'],
     })
+  })
+
+  it('joins array index paths with dots', () => {
+    const schema = z.object({
+      files: z.array(z.object({ key: z.string() })),
+    })
+    const errors = [
+      new InputError('Required', ['files', '0', 'key']),
+      new InputError('Required', ['files', '1', 'key']),
+    ]
+
+    const result = errorMessagesForSchema(errors, schema)
+
+    expect(result).toEqual({
+      'files.0.key': ['Required'],
+      'files.1.key': ['Required'],
+    })
+  })
+
+  it('skips input errors with empty paths', () => {
+    const schema = z.object({ name: z.string() })
+    const errors = [
+      new InputError('Empty path', []),
+      new InputError('Required', ['name']),
+    ]
+
+    const result = errorMessagesForSchema(errors, schema)
+
+    expect(result).toEqual({ name: ['Required'] })
   })
 })
 

--- a/packages/remix-forms/src/mutations.test.ts
+++ b/packages/remix-forms/src/mutations.test.ts
@@ -133,7 +133,7 @@ describe('performMutation', () => {
     expect(mutation).toHaveBeenCalledWith({ name: 'JANE' }, context)
   })
 
-  it('returns nested errors structured by path', async () => {
+  it('returns dot-path errors for nested schemas', async () => {
     const schema = z.object({
       user: z.object({
         name: z.string(),
@@ -157,8 +157,8 @@ describe('performMutation', () => {
 
     expect(result.success).toBe(false)
     if (!result.success) {
-      const errors = result.errors as { user?: { name?: string[] } }
-      expect(errors.user?.name).toEqual(['Required'])
+      const errors = result.errors as Record<string, string[]>
+      expect(errors['user.name']).toEqual(['Required'])
       const values = result.values as {
         user?: { name?: string; age?: string }
       }

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -13,75 +13,42 @@ import type { FormSchema, Infer } from './prelude'
 
 type DataWithResponseInit<T> = ReturnType<typeof data<T>>
 
-type NestedErrors<SchemaType> = {
-  [Property in keyof SchemaType]: string[] | NestedErrors<SchemaType[Property]>
-}
-
 /**
- * Build a nested error object from a list of {@link InputError|InputErrors}.
+ * Build a flat error map from a list of {@link InputError|InputErrors}.
+ *
+ * Nested paths are joined with `'.'` so the returned keys align with
+ * React Hook Form's {@link https://react-hook-form.com/docs/useform/seterror | Path} notation.
  *
  * @param errors - Errors returned by the mutation
  * @param schema - Schema describing the expected values
- * @returns Nested map of error messages keyed by path
+ * @returns Flat map of dot-path keys to error message arrays
  *
  * @example
  * ```ts
- * const errors = [new InputError('Required', ['name'])]
+ * const errors = [new InputError('Required', ['user', 'name'])]
  * errorMessagesForSchema(errors, schema)
+ * // => { 'user.name': ['Required'] }
  * ```
  */
 function errorMessagesForSchema<T extends StandardSchemaV1>(
   errors: Error[],
   _schema: T
-): NestedErrors<Infer<T>> {
-  type SchemaType = Infer<T>
-  type ErrorObject = { path: string[]; messages: string[] }
-
+): FormErrors<Infer<T>> {
   const inputErrors = errors.filter(isInputError) as InputError[]
 
-  const nest = (
-    { path, messages }: ErrorObject,
-    root: Record<string, unknown>
-  ) => {
-    const [head, ...tail] = path
-    root[head] =
-      tail.length === 0
-        ? messages
-        : nest(
-            { path: tail, messages },
-            (root[head] as Record<string, unknown>) ?? {}
-          )
-    return root
+  const result: Record<string, string[]> = {}
+
+  for (const error of inputErrors) {
+    if (error.path.length === 0) continue
+    const key = error.path.join('.')
+    if (result[key]) {
+      result[key].push(error.message)
+    } else {
+      result[key] = [error.message]
+    }
   }
 
-  const compareStringArrays = (a: string[]) => (b: string[]) =>
-    JSON.stringify(a) === JSON.stringify(b)
-
-  const toErrorObject = (errors: InputError[]): ErrorObject[] =>
-    errors.map(({ path, message }) => ({
-      path,
-      messages: [message],
-    }))
-
-  const unifyPaths = (errors: InputError[]) =>
-    toErrorObject(errors).reduce((memo, error) => {
-      const comparePath = compareStringArrays(error.path)
-      const mergeErrorMessages = ({ path, messages }: ErrorObject) =>
-        comparePath(path)
-          ? { path, messages: [...messages, ...error.messages] }
-          : { path, messages }
-      const existingPath = memo.find(({ path }) => comparePath(path))
-
-      return existingPath ? memo.map(mergeErrorMessages) : [...memo, error]
-    }, [] as ErrorObject[])
-
-  const errorTree = unifyPaths(inputErrors).reduce((memo, schemaError) => {
-    const errorBranch = nest(schemaError, memo)
-
-    return { ...memo, ...errorBranch }
-  }, {}) as NestedErrors<SchemaType>
-
-  return errorTree
+  return result as FormErrors<Infer<T>>
 }
 
 type FormActionFailure<SchemaType> = {
@@ -92,8 +59,8 @@ type FormActionFailure<SchemaType> = {
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 type FormValues<SchemaType> = Partial<Record<keyof SchemaType, any>>
 
-type FormErrors<SchemaType> = Partial<
-  Record<keyof SchemaType | '_global', string[]>
+type FormErrors<SchemaType = Record<string, unknown>> = Partial<
+  Record<(keyof SchemaType & string) | '_global' | (string & {}), string[]>
 >
 
 /**

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -508,3 +508,41 @@ it('uses fieldsComponent to wrap auto-generated fields', () => {
 
   expect(html).toContain('data-fields="true"')
 })
+
+it('promotes dot-path errors to global errors', () => {
+  const schema = z.object({
+    user: z.object({ name: z.string() }),
+  })
+
+  const html = renderToStaticMarkup(
+    <SchemaForm
+      schema={schema}
+      errors={
+        { 'user.name': ['Required'] } as Parameters<
+          typeof SchemaForm<typeof schema>
+        >[0]['errors']
+      }
+    />
+  )
+
+  expect(html).toContain('role="alert"')
+  expect(html).toContain('Required')
+})
+
+it('promotes dot-path errors from action data to global errors', () => {
+  const schema = z.object({
+    user: z.object({ name: z.string(), age: z.number() }),
+  })
+  const mockUseActionData = vi.mocked(useActionData)
+
+  mockUseActionData.mockReturnValueOnce({
+    errors: { 'user.name': ['Required'], 'user.age': ['Invalid'] },
+    values: {},
+  })
+
+  const html = renderToStaticMarkup(<SchemaForm schema={schema} />)
+
+  expect(html).toContain('role="alert"')
+  expect(html).toContain('Required')
+  expect(html).toContain('Invalid')
+})

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -381,7 +381,7 @@ function SchemaForm<Schema extends FormSchema>({
   )
 
   const fieldErrors = React.useCallback(
-    (key: keyof SchemaType) => {
+    (key: keyof SchemaType & string) => {
       const message = (formErrors[key] as unknown as FieldError)?.message
       return browser() ? message && [message] : errors?.[key]
     },
@@ -433,7 +433,9 @@ function SchemaForm<Schema extends FormSchema>({
   const hiddenFieldsErrorsToGlobal = React.useCallback(
     (globalErrors: string[] = []) => {
       const deepHiddenFieldsErrors = hiddenFields?.map((hiddenField) => {
-        const hiddenFieldErrors = fieldErrors(hiddenField)
+        const hiddenFieldErrors = fieldErrors(
+          hiddenField as keyof SchemaType & string
+        )
 
         if (Array.isArray(hiddenFieldErrors)) {
           const hiddenFieldLabel =
@@ -455,9 +457,20 @@ function SchemaForm<Schema extends FormSchema>({
     [fieldErrors, hiddenFields, labels]
   )
 
+  const orphanedErrors = React.useMemo(() => {
+    const fieldKeys = new Set(Object.keys(fields))
+    return Object.entries(errors)
+      .filter(([key]) => key !== '_global' && !fieldKeys.has(key))
+      .flatMap(([, msgs]) => msgs ?? [])
+  }, [errors, fields])
+
   const globalErrors = React.useMemo(
-    () => hiddenFieldsErrorsToGlobal(errors?._global),
-    [errors?._global, hiddenFieldsErrorsToGlobal]
+    () =>
+      hiddenFieldsErrorsToGlobal([
+        ...(errors?._global ?? []),
+        ...orphanedErrors,
+      ]),
+    [errors?._global, orphanedErrors, hiddenFieldsErrorsToGlobal]
   )
 
   const buttonLabel =
@@ -590,6 +603,7 @@ function SchemaForm<Schema extends FormSchema>({
 
   React.useEffect(() => {
     Object.keys(errors).forEach((key) => {
+      if (key === '_global') return
       form.setError(key as Path<Infer<Schema>>, {
         type: 'custom',
         message: (errors[key] ?? []).join(', '),


### PR DESCRIPTION
## Summary

Fixes #387.

- **`errorMessagesForSchema` now returns flat dot-path keys** (e.g. `'user.name': ['Required']`) instead of nested objects (`{ user: { name: ['Required'] } }`), aligning with React Hook Form's `Path<T>` notation
- **`FormErrors` type updated** to accept dot-path keys via `(string & {})` while preserving autocomplete for top-level schema keys
- **Orphaned dot-path errors promoted to global errors** in `SchemaForm`, since only top-level fields are rendered
- **Skips `_global` key** in the `setError` loop (not a field path)

This is a **breaking change**: `errorMessagesForSchema` return shape changed from nested objects to flat dot-path keys.

## Test plan

- [x] `pnpm run tsc` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (156 tests)
- [x] New tests for flat single-segment paths, array index paths, empty paths
- [x] New tests for dot-path error promotion to global errors (from props and action data)
- [x] Updated existing nested error tests to expect dot-path keys