### PR TITLE
Fix false-positive element type comparisons

### DIFF
--- a/.claude/skills/safe-element-comparison/SKILL.md
+++ b/.claude/skills/safe-element-comparison/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: safe-element-comparison
+description: Maintain element type comparison safety in remix-forms. Use when modifying component mappings, adding new components to mapChildren, investigating unexpected HTML attributes or prop injection, writing docs about component customization, or responding to user issues about wrong elements receiving props.
+metadata:
+  internal: true
+---
+
+# Safe Element Comparison
+
+remix-forms identifies components in JSX trees using `child.type === Component`. This pattern is central to how `mapChildren` injects props into the right elements. This skill covers the architecture, the rules for keeping it safe, and guidance for users.
+
+## How It Works
+
+`mapChildren` in `children-traversal.ts` recursively walks the React element tree returned by user render functions. Callback functions in `create-field.tsx` and `schema-form.tsx` compare `child.type` against component references to decide which props to inject.
+
+React element types follow these rules:
+
+- `<div>` compiles to `React.createElement('div')` — type is the **string** `'div'`
+- `<MyComponent />` compiles to `React.createElement(MyComponent)` — type is the **function/object reference**
+- `React.forwardRef(fn)` returns a unique object — `===` comparison works reliably when defined at module scope
+- `React.cloneElement` preserves `.type` exactly
+- React Fast Refresh preserves component identity in development
+
+If a component reference were a string like `'div'`, then `child.type === Component` would match every `<div>` in the tree — not just the intended component. This is why all default components are `React.forwardRef` wrappers with unique object identity.
+
+## Current Architecture
+
+All default components are defined at module scope as `React.forwardRef` wrappers. Each renders its corresponding HTML element and nothing else. Components that render the same HTML tag (e.g. `DefaultInput`, `DefaultCheckbox`, `DefaultRadio` all render `<input>`) are separate objects with distinct identities.
+
+### create-field.tsx
+
+| Default wrapper | Renders | Used as default for |
+|---|---|---|
+| `DefaultField` | `<div>` | `fieldComponent` |
+| `DefaultLabel` | `<label>` | `labelComponent` |
+| `DefaultInput` | `<input>` | `inputComponent` |
+| `DefaultMultiline` | `<textarea>` | `multilineComponent` |
+| `DefaultSelect` | `<select>` | `selectComponent` |
+| `DefaultCheckbox` | `<input>` | `checkboxComponent` |
+| `DefaultRadio` | `<input>` | `radioComponent` |
+| `DefaultRadioGroup` | `<fieldset>` | `radioGroupComponent` |
+| `DefaultRadioWrapper` | `<div>` | `radioWrapperComponent` |
+| `DefaultCheckboxWrapper` | `<div>` | `checkboxWrapperComponent` |
+| `DefaultFieldErrors` | `<div>` | `fieldErrorsComponent` |
+| `DefaultFieldError` | `<div>` | `errorComponent` |
+
+### schema-form.tsx
+
+| Default wrapper | Renders | Used as default for |
+|---|---|---|
+| `DefaultFieldsWrapper` | `<div>` | `fieldsComponent` |
+| `DefaultGlobalErrors` | `<div>` | `globalErrorsComponent` |
+| `DefaultButton` | `<button>` | `buttonComponent` |
+
+`DefaultFieldError` is imported from `create-field.tsx` and reused as the default for `errorComponent` in `SchemaForm`.
+
+## Rules for Development
+
+### Adding a new component mapping
+
+1. Create a `Default*` forwardRef wrapper at **module scope** in the appropriate file.
+2. Use it as the default parameter value — never use a string tag name.
+3. If the component will be compared via `child.type ===` in any `mapChildren` callback, write a test verifying plain HTML elements of the same tag are not affected.
+4. Update the inventory table in this skill.
+
+### Modifying existing components
+
+- Preserve unique identity. Each default must be its own distinct object, even when multiple defaults render the same HTML tag.
+- Keep defaults at module scope. Moving them inside a function creates new references each call, breaking `===` comparisons and causing React remounts.
+
+### Never do
+
+- **Never use a string tag name as a default** — it matches every element of that tag in the tree.
+- **Never wrap defaults in `React.memo()`** — memo creates a new wrapper object; `child.type === original` silently fails.
+- **Never wrap defaults in `React.lazy()`** — lazy also creates a wrapper that doesn't match the inner component.
+- **Never define defaults inside render functions** — new identity each render breaks `===` and causes full remounts.
+
+## User-Facing Guidance
+
+When communicating with users about component customization:
+
+### Passing custom components
+
+- **Recommended**: Pass a React component (function, class, or forwardRef). The `===` comparison is safe because each component has a unique reference.
+- **Not recommended**: Pass a string tag name like `"div"`. The comparison becomes ambiguous — any element of that tag in the children function will be matched.
+- When a user reports unexpected attributes on their elements, check whether they passed a string for a component prop.
+
+### The React.memo limitation
+
+If a user wraps a custom component in `React.memo()` before passing it, the comparison will fail silently — `memo()` creates a wrapper object that doesn't match the inner component. This is an inherent limitation of the `child.type ===` pattern. Advise users to pass the unwrapped component.
+
+### What users should know
+
+- Components passed to `SchemaForm` (like `inputComponent`, `labelComponent`, etc.) are identified by reference equality in the JSX tree.
+- Custom HTML elements of the same tag type as a component prop will not be misidentified — the library's defaults use unique component wrappers.
+- When using the children render function pattern (`renderField` or `SchemaForm` children), any component received from the helpers object (e.g. `Label`, `Input`, `Errors`) has special identity that the library uses to inject the right props.
+
+## Diagnosing Issues
+
+When a user reports unexpected HTML attributes (e.g. `role="alert"` on a wrapper div, or `name="..."` on an unrelated input):
+
+1. **Check if they're using the children render function** — this is where `mapChildren` runs and where false matches can occur.
+2. **Check if they passed a string for a component prop** — e.g. `fieldErrorsComponent="div"`. This restores the ambiguity the defaults are designed to prevent.
+3. **Check if they wrapped a component in `React.memo()`** — this causes false negatives (the component is NOT recognized, so it doesn't receive its intended props).
+4. **Check `mapChildren` callbacks** — verify that the `child.type ===` comparison targets the correct variable and that the variable is a unique component reference.
+5. **Check for new comparisons** — if someone added a new `child.type ===` check, verify it follows the rules above.
+
+## Testing
+
+For each component compared in `mapChildren`, maintain a regression test that:
+
+1. Renders a Field (or SchemaForm) with a children function.
+2. Includes BOTH the library component AND a plain HTML element of the same tag.
+3. Asserts the library component receives injected props.
+4. Asserts the plain HTML element does NOT receive injected props.
+
+Existing tests live in `create-field.test.tsx` (describe block: "element type comparison safety") and `schema-form.test.tsx` (describe block: "element type comparison safety").

--- a/apps/web/app/routes/get-started.tsx
+++ b/apps/web/app/routes/get-started.tsx
@@ -242,6 +242,12 @@ export default function Component({ loaderData }: Route.ComponentProps) {
           PS: you don&apos;t need to customize everything. We&apos;ll use
           standard html tags if you don&apos;t.
         </p>
+        <p>
+          When passing custom components, always pass actual React components
+          rather than string tag names like <em>&quot;div&quot;</em> or{' '}
+          <em>&quot;input&quot;</em>. Remix Forms identifies these components by
+          reference in the JSX tree, so strings can cause unexpected behavior.
+        </p>
       </div>
       <SubHeading>That&apos;s it!</SubHeading>
       <div className="flex flex-col gap-2">

--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -396,3 +396,93 @@ describe('component mappings', () => {
     expect(radioHtml).toContain('data-radio="true"')
   })
 })
+
+describe('element type comparison safety', () => {
+  it('does not inject error props into plain div elements', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" errors={['Oops']}>
+        {({ Errors }) => (
+          <>
+            <div className="wrapper">content</div>
+            <Errors />
+          </>
+        )}
+      </Field>
+    )
+
+    expect(html).toContain('role="alert"')
+    expect(html).not.toMatch(/class="wrapper"[^>]*role="alert"/)
+  })
+
+  it('does not inject label props into plain label elements', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo">
+        {({ Label, SmartInput }) => (
+          <>
+            <label htmlFor="other">Other</label>
+            <Label />
+            <SmartInput />
+          </>
+        )}
+      </Field>
+    )
+
+    expect(html).toContain('for="other"')
+    expect(html).toContain('id="label-for-foo"')
+    const otherLabel = html.match(/<label[^>]*for="other"[^>]*>/)
+    expect(otherLabel?.[0]).not.toContain('id="label-for-foo"')
+  })
+
+  it('does not inject input props into plain input elements', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo">
+        {({ Input }) => (
+          <>
+            <input type="text" data-custom="true" />
+            <Input />
+          </>
+        )}
+      </Field>
+    )
+
+    expect(html).toContain('data-custom="true"')
+    const customInput = html.match(/<input[^>]*data-custom="true"[^>]*/)
+    expect(customInput?.[0]).not.toContain('name="foo"')
+  })
+
+  it('does not inject select props into plain select elements', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" options={[{ name: 'A', value: 'a' }]}>
+        {({ Select }) => (
+          <>
+            <select data-custom="true">
+              <option>X</option>
+            </select>
+            <Select />
+          </>
+        )}
+      </Field>
+    )
+
+    expect(html).toContain('data-custom="true"')
+    const customSelect = html.match(/<select[^>]*data-custom="true"[^>]*/)
+    expect(customSelect?.[0]).not.toContain('name="foo"')
+  })
+
+  it('does not inject textarea props into plain textarea elements', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" multiline>
+        {({ Multiline }) => (
+          <>
+            <textarea data-custom="true" />
+            <Multiline />
+          </>
+        )}
+      </Field>
+    )
+
+    expect(html).toContain('data-custom="true"')
+    const customTextarea = html.match(/<textarea[^>]*data-custom="true"[^>]*/)
+    expect(customTextarea?.[0]).not.toContain('name="foo"')
+  })
+})

--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -185,6 +185,67 @@ export function useField() {
   return context
 }
 
+const DefaultField = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
+const DefaultLabel = React.forwardRef<
+  HTMLLabelElement,
+  JSX.IntrinsicElements['label']
+  // biome-ignore lint/a11y/noLabelWithoutControl: wrapper component, association happens at render time
+>((props, ref) => <label {...props} ref={ref} />)
+
+const DefaultInput = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>((props, ref) => <input {...props} ref={ref} />)
+
+const DefaultMultiline = React.forwardRef<
+  HTMLTextAreaElement,
+  JSX.IntrinsicElements['textarea']
+>((props, ref) => <textarea {...props} ref={ref} />)
+
+const DefaultSelect = React.forwardRef<
+  HTMLSelectElement,
+  JSX.IntrinsicElements['select']
+>((props, ref) => <select {...props} ref={ref} />)
+
+const DefaultCheckbox = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>((props, ref) => <input {...props} ref={ref} />)
+
+const DefaultRadio = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>((props, ref) => <input {...props} ref={ref} />)
+
+const DefaultRadioGroup = React.forwardRef<
+  HTMLFieldSetElement,
+  JSX.IntrinsicElements['fieldset']
+>((props, ref) => <fieldset {...props} ref={ref} />)
+
+const DefaultRadioWrapper = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
+const DefaultCheckboxWrapper = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
+const DefaultFieldErrors = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
+const DefaultFieldError = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
 const makeSelectOption = ({ name, value }: Option) => (
   <option key={String(value)} value={value}>
     {name}
@@ -197,13 +258,13 @@ const makeOptionComponents = (
 ) => (options ? options.map(fn) : undefined)
 
 function createSmartInput({
-  inputComponent: Input = 'input',
-  multilineComponent: Multiline = 'textarea',
-  selectComponent: Select = 'select',
-  checkboxComponent: Checkbox = 'input',
-  labelComponent: Label = 'label',
-  radioComponent: Radio = 'input',
-  radioWrapperComponent: RadioWrapper = 'div',
+  inputComponent: Input = DefaultInput,
+  multilineComponent: Multiline = DefaultMultiline,
+  selectComponent: Select = DefaultSelect,
+  checkboxComponent: Checkbox = DefaultCheckbox,
+  labelComponent: Label = DefaultLabel,
+  radioComponent: Radio = DefaultRadio,
+  radioWrapperComponent: RadioWrapper = DefaultRadioWrapper,
 }: ComponentMappings) {
   return ({
     fieldType,
@@ -286,18 +347,18 @@ function createSmartInput({
 
 function createField<Schema extends FormSchema>({
   register,
-  fieldComponent: Field = 'div',
-  labelComponent: Label = 'label',
-  inputComponent: Input = 'input',
-  multilineComponent: Multiline = 'textarea',
-  selectComponent: Select = 'select',
-  radioComponent: Radio = 'input',
-  checkboxComponent: Checkbox = 'input',
-  checkboxWrapperComponent: CheckboxWrapper = 'div',
-  radioGroupComponent: RadioGroup = 'fieldset',
-  radioWrapperComponent: RadioWrapper = 'div',
-  fieldErrorsComponent: Errors = 'div',
-  errorComponent: Error = 'div',
+  fieldComponent: Field = DefaultField,
+  labelComponent: Label = DefaultLabel,
+  inputComponent: Input = DefaultInput,
+  multilineComponent: Multiline = DefaultMultiline,
+  selectComponent: Select = DefaultSelect,
+  radioComponent: Radio = DefaultRadio,
+  checkboxComponent: Checkbox = DefaultCheckbox,
+  checkboxWrapperComponent: CheckboxWrapper = DefaultCheckboxWrapper,
+  radioGroupComponent: RadioGroup = DefaultRadioGroup,
+  radioWrapperComponent: RadioWrapper = DefaultRadioWrapper,
+  fieldErrorsComponent: Errors = DefaultFieldErrors,
+  errorComponent: Error = DefaultFieldError,
 }: {
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   register: UseFormRegister<any>
@@ -625,4 +686,4 @@ function createField<Schema extends FormSchema>({
 }
 
 export type { FieldType, FieldComponent, ComponentMappings, Option }
-export { createField }
+export { createField, DefaultFieldError }

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -546,3 +546,50 @@ it('promotes dot-path errors from action data to global errors', () => {
   expect(html).toContain('Required')
   expect(html).toContain('Invalid')
 })
+
+describe('element type comparison safety', () => {
+  it('does not inject error props into plain div elements in children', () => {
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} errors={{ _global: ['Oops'] }}>
+        {({ Field, Errors }) => (
+          <>
+            <div className="wrapper">
+              <Field name="name" />
+            </div>
+            <Errors />
+          </>
+        )}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('role="alert"')
+    expect(html).not.toMatch(/class="wrapper"[^>]*role="alert"/)
+  })
+
+  it('does not inject button props into plain button elements in children', () => {
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema}>
+        {({ Field, Button }) => (
+          <>
+            <Field name="name" />
+            <button type="button" data-custom="true">
+              Cancel
+            </button>
+            <Button />
+          </>
+        )}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('data-custom="true"')
+    const customButton = html.match(
+      /<button[^>]*data-custom="true"[^>]*>[^<]*<\/button>/
+    )
+    expect(customButton?.[0]).toContain('Cancel')
+    expect(customButton?.[0]).not.toContain('OK')
+  })
+})

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -27,7 +27,7 @@ import type {
   FieldType,
   Option,
 } from './create-field'
-import { createField } from './create-field'
+import { DefaultFieldError, createField } from './create-field'
 import { defaultRenderField } from './default-render-field'
 import { inferLabel } from './infer-label'
 import type { FormErrors, FormValues } from './mutations'
@@ -38,6 +38,21 @@ import type {
   KeysOfStrings,
 } from './prelude'
 import { browser, mapObject } from './prelude'
+
+const DefaultFieldsWrapper = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
+const DefaultGlobalErrors = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>((props, ref) => <div {...props} ref={ref} />)
+
+const DefaultButton = React.forwardRef<
+  HTMLButtonElement,
+  JSX.IntrinsicElements['button']
+>((props, ref) => <button {...props} ref={ref} />)
 
 type Field<SchemaType> = {
   shape: SchemaInfo
@@ -245,10 +260,10 @@ function SchemaForm<Schema extends FormSchema>({
   mode = 'onSubmit',
   reValidateMode = 'onChange',
   renderField = defaultRenderField,
-  fieldsComponent: FieldsComponent = 'div',
+  fieldsComponent: FieldsComponent = DefaultFieldsWrapper,
   fieldComponent,
-  globalErrorsComponent: Errors = 'div',
-  errorComponent: Error = 'div',
+  globalErrorsComponent: Errors = DefaultGlobalErrors,
+  errorComponent: Error = DefaultFieldError,
   fieldErrorsComponent,
   labelComponent,
   inputComponent,
@@ -259,7 +274,7 @@ function SchemaForm<Schema extends FormSchema>({
   checkboxWrapperComponent,
   radioGroupComponent,
   radioWrapperComponent,
-  buttonComponent: Button = 'button',
+  buttonComponent: Button = DefaultButton,
   buttonLabel: rawButtonLabel = 'OK',
   pendingButtonLabel,
   method = 'POST',


### PR DESCRIPTION
## Summary

- Replace all string tag name defaults (`'div'`, `'input'`, `'label'`, etc.) with unique `React.forwardRef` wrapper components at module scope
- This prevents `child.type === Component` in `mapChildren` from matching every HTML element of that tag type in the user's JSX tree — only the intended library component is matched
- Add regression tests verifying plain HTML elements don't receive injected props
- Add a note to the Get Started page advising users to pass React components rather than string tag names
- Add internal `safe-element-comparison` skill documenting the architecture and rules

Closes #302

## Test plan

- [x] `pnpm run tsc` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes — 163 unit tests (7 new regression tests) + 89 integration tests