### PR TITLE
Add autoInputTypes prop for format-based input type detection

### DIFF
--- a/packages/remix-forms/package.json
+++ b/packages/remix-forms/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "coerce-form-data": ">=2",
-    "schema-info": ">=0.1.0",
+    "schema-info": ">=0.3.0",
     "composable-functions": ">=5",
     "react": ">=18",
     "react-hook-form": ">=7.27",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "coerce-form-data": "2.0.0",
-    "schema-info": "0.1.0",
+    "schema-info": "0.3.0",
     "arktype": "^2.2.0",
     "effect": "^3.20.0",
     "joi": "^18.0.2",

--- a/packages/remix-forms/src/index.ts
+++ b/packages/remix-forms/src/index.ts
@@ -3,6 +3,7 @@ export { useField } from './create-field'
 export { formAction, performMutation } from './mutations'
 
 export type {
+  AutoInputType,
   SchemaFormProps,
   RenderFieldProps,
   RenderField,

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -547,6 +547,67 @@ it('promotes dot-path errors from action data to global errors', () => {
   expect(html).toContain('Invalid')
 })
 
+describe('autoInputTypes', () => {
+  it('auto-detects date input type from schema format by default', () => {
+    const schema = z.object({ birthday: z.string().date() })
+    const html = renderToStaticMarkup(<SchemaForm schema={schema} />)
+    expect(html).toContain('type="date"')
+  })
+
+  it('auto-detects datetime-local input type from schema format by default', () => {
+    const schema = z.object({ createdAt: z.string().datetime() })
+    const html = renderToStaticMarkup(<SchemaForm schema={schema} />)
+    expect(html).toContain('type="datetime-local"')
+  })
+
+  it('auto-detects time input type from schema format by default', () => {
+    const schema = z.object({ alarm: z.string().time() })
+    const html = renderToStaticMarkup(<SchemaForm schema={schema} />)
+    expect(html).toContain('type="time"')
+  })
+
+  it('does not auto-detect email input type by default', () => {
+    const schema = z.object({ email: z.string().email() })
+    const html = renderToStaticMarkup(<SchemaForm schema={schema} />)
+    expect(html).toContain('type="text"')
+  })
+
+  it('auto-detects email when included in autoInputTypes', () => {
+    const schema = z.object({ email: z.string().email() })
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        autoInputTypes={['date', 'datetime-local', 'time', 'email']}
+      />
+    )
+    expect(html).toContain('type="email"')
+  })
+
+  it('auto-detects url when included in autoInputTypes', () => {
+    const schema = z.object({ website: z.string().url() })
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} autoInputTypes={['url']} />
+    )
+    expect(html).toContain('type="url"')
+  })
+
+  it('disables all format auto-detection when autoInputTypes is empty', () => {
+    const schema = z.object({ birthday: z.string().date() })
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} autoInputTypes={[]} />
+    )
+    expect(html).toContain('type="text"')
+  })
+
+  it('prefers explicit inputTypes over auto-detected format', () => {
+    const schema = z.object({ birthday: z.string().date() })
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} inputTypes={{ birthday: 'text' }} />
+    )
+    expect(html).toContain('type="text"')
+  })
+})
+
 describe('element type comparison safety', () => {
   it('does not inject error props into plain div elements in children', () => {
     const schema = z.object({ name: z.string() })

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -54,6 +54,21 @@ const DefaultButton = React.forwardRef<
   JSX.IntrinsicElements['button']
 >((props, ref) => <button {...props} ref={ref} />)
 
+/**
+ * HTML input types that can be automatically inferred from a schema
+ * field's {@link SchemaInfo.format | format} metadata.
+ *
+ * When a field's format maps to one of these input types and that type is
+ * included in the {@link SchemaFormProps.autoInputTypes | autoInputTypes}
+ * array, the corresponding `<input type="...">` is set automatically.
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} autoInputTypes={['date', 'email']} />
+ * ```
+ */
+type AutoInputType = 'date' | 'datetime-local' | 'time' | 'email' | 'url'
+
 type Field<SchemaType> = {
   shape: SchemaInfo
   fieldType: FieldType
@@ -176,6 +191,7 @@ type SchemaFormProps<Schema extends FormSchema> = ComponentMappings & {
   inputTypes?: Partial<
     Record<keyof Infer<Schema>, React.HTMLInputTypeAttribute>
   >
+  autoInputTypes?: AutoInputType[]
   multiline?: Array<keyof Infer<Schema>>
   radio?: Array<KeysOfStrings<Infer<Schema>>>
   autoFocus?: keyof Infer<Schema>
@@ -185,6 +201,24 @@ type SchemaFormProps<Schema extends FormSchema> = ComponentMappings & {
   idPrefix?: string
   flushSync?: boolean
 } & Omit<ReactRouterFormProps, 'children' | 'autoFocus'>
+
+const formatToInputType: Partial<Record<string, AutoInputType>> = {
+  date: 'date',
+  datetime: 'datetime-local',
+  time: 'time',
+  email: 'email',
+  url: 'url',
+}
+
+function resolveAutoInputType(
+  info: SchemaInfo,
+  allowedTypes: AutoInputType[]
+): AutoInputType | undefined {
+  if (!info.format) return undefined
+  const mapped = formatToInputType[info.format]
+  if (!mapped || !allowedTypes.includes(mapped)) return undefined
+  return mapped
+}
 
 function uiFieldType(info: SchemaInfo): FieldType {
   if (info.type === 'enum') return 'string'
@@ -230,6 +264,7 @@ function uiFieldType(info: SchemaInfo): FieldType {
  * @param props.placeholders - Placeholder text for fields
  * @param props.options - Select and radio options for fields
  * @param props.inputTypes - Custom input types per field
+ * @param props.autoInputTypes - HTML input types to assign automatically based on schema format. Defaults to `['date', 'datetime-local', 'time']`
  * @param props.hiddenFields - Fields rendered as hidden inputs
  * @param props.multiline - Fields rendered with the multiline component
  * @param props.radio - Fields rendered as radio groups
@@ -288,6 +323,7 @@ function SchemaForm<Schema extends FormSchema>({
   placeholders,
   options,
   inputTypes,
+  autoInputTypes = ['date', 'datetime-local', 'time'],
   emptyOptionLabel = '',
   hiddenFields,
   multiline,
@@ -435,7 +471,7 @@ function SchemaForm<Schema extends FormSchema>({
     return {
       shape: info,
       fieldType: uiFieldType(info),
-      type: inputTypes?.[key],
+      type: inputTypes?.[key] ?? resolveAutoInputType(info, autoInputTypes),
       name: key,
       required,
       dirty: key in formState.dirtyFields,
@@ -653,6 +689,7 @@ function SchemaForm<Schema extends FormSchema>({
 }
 
 export type {
+  AutoInputType,
   Field,
   RenderFieldProps,
   RenderField,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
         specifier: 7.13.1
         version: 7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       schema-info:
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.3.0
+        version: 0.3.0
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.8.3)(yaml@2.8.2)
@@ -2337,8 +2337,8 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  schema-info@0.1.0:
-    resolution: {integrity: sha512-a23vxOR0QS3bJiuYP3eWdtOtatx6TmWOHBNdpAdTRbJHimrWtR13nO8s0Fmqm901uFmX1gkPeR/FE7ZtDF+k8Q==}
+  schema-info@0.3.0:
+    resolution: {integrity: sha512-qpdxWeRSctUQSTtOXnRM17fgG0x2eMJhf5+3JvMDmQLFB3JlYXszJYhq9YYOpZNAdU6nY7dSeN4iKfjH+ZCTwg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4590,7 +4590,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  schema-info@0.1.0: {}
+  schema-info@0.3.0: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## Summary

- Adds a new optional `autoInputTypes` prop to `SchemaForm` that automatically sets HTML input types based on schema format metadata from schema-info v0.3.0
- Exports new `AutoInputType` type (`'date' | 'datetime-local' | 'time' | 'email' | 'url'`)
- Defaults to `['date', 'datetime-local', 'time']` — safe defaults that improve UX without surprises
- Explicit `inputTypes` prop still takes precedence over auto-detection
- Bumps schema-info peer dependency to `>=0.3.0`

### How it works

schema-info v0.3.0 now provides a `format` field on `SchemaInfo` (e.g. `'email'`, `'datetime'`, `'url'`). This PR maps those formats to HTML input types and automatically applies them when the corresponding type is in the `autoInputTypes` array.

| Schema | Format detected | Auto input type |
|---|---|---|
| `z.string().date()` | `date` | `date` |
| `z.string().datetime()` | `datetime` | `datetime-local` |
| `z.string().time()` | `time` | `time` |
| `z.string().email()` | `email` | `email` |
| `z.string().url()` | `url` | `url` |

### Usage

```tsx
// Default: auto-detects date, datetime-local, and time
<SchemaForm schema={schema} />

// Opt in to more types
<SchemaForm schema={schema} autoInputTypes={['date', 'datetime-local', 'time', 'email', 'url']} />

// Disable all auto-detection
<SchemaForm schema={schema} autoInputTypes={[]} />
```

## Closes

- Closes #39 — `z.string().datetime()` now auto-renders as `<input type="datetime-local">`
- Closes #83 — schema format info (email, url, date, etc.) is now used to automatically set input types, removing the need to manually infer format from the schema

## Related

- Related to #381 — `z.date()` already renders as `type="date"` via the existing `type` → `FieldType` mapping; this PR additionally handles `z.string().date()` via the new `format` field

## Test plan

- [x] Unit tests: 8 new tests covering defaults, customization, disabling, and precedence
- [x] All 171 unit tests pass
- [x] All 89 Playwright E2E tests pass
- [x] TypeScript compiles cleanly
- [x] Biome lint passes