### PR TITLE
Add schema-level autoComplete prop to SchemaForm

### DIFF
--- a/apps/web/app/routes/examples/labels-options-etc.spec.ts
+++ b/apps/web/app/routes/examples/labels-options-etc.spec.ts
@@ -5,6 +5,7 @@ const route = '/examples/forms/labels-options-etc'
 test('With JS enabled', async ({ example }) => {
   const { button, page } = example
   const name = example.field('name')
+  const email = example.field('email')
   const roleId = example.field('roleId')
   const bio = example.field('bio')
 
@@ -12,6 +13,8 @@ test('With JS enabled', async ({ example }) => {
 
   // Render
   await example.expectField(name)
+  await example.expectField(email)
+  await expect(email.input).toHaveAttribute('autocomplete', 'email')
   await example.expectSelect(roleId, { label: 'Role', value: '' })
   await example.expectField(bio, { multiline: true })
   const options = roleId.input.locator('option')
@@ -30,17 +33,23 @@ test('With JS enabled', async ({ example }) => {
     'Too small: expected string to have >=1 characters'
   )
   await example.expectError(
+    email,
+    'Too small: expected string to have >=1 characters'
+  )
+  await example.expectError(
     bio,
     'Too small: expected string to have >=1 characters'
   )
 
   await expect(name.input).toBeFocused()
 
-  // Make first and second fields valid, focus goes to the second field
+  // Make first and second fields valid, focus goes to the third field
   await name.input.fill('John')
+  await email.input.fill('john@example.com')
   await roleId.input.selectOption({ value: '1' })
   await button.click()
   await example.expectValid(name)
+  await example.expectValid(email)
   await expect(bio.input).toBeFocused()
 
   // Make form be valid
@@ -54,6 +63,7 @@ test('With JS enabled', async ({ example }) => {
 
   await example.expectData({
     name: 'John',
+    email: 'john@example.com',
     bio: 'My bio',
     roleId: 2,
   })
@@ -62,11 +72,13 @@ test('With JS enabled', async ({ example }) => {
 testWithoutJS('With JS disabled', async ({ example }) => {
   const { button, page } = example
   const name = example.field('name')
+  const email = example.field('email')
   const roleId = example.field('roleId')
   const bio = example.field('bio')
 
   await page.goto(route)
   await example.expectAutoFocus(name)
+  await expect(email.input).toHaveAttribute('autocomplete', 'email')
 
   // Server-side validation
   await button.click()
@@ -77,6 +89,11 @@ testWithoutJS('With JS disabled', async ({ example }) => {
     name,
     'Too small: expected string to have >=1 characters'
   )
+  await example.expectErrors(
+    email,
+    'Too small: expected string to have >=1 characters',
+    'Invalid email address'
+  )
   await example.expectError(
     bio,
     'Too small: expected string to have >=1 characters'
@@ -84,11 +101,13 @@ testWithoutJS('With JS disabled', async ({ example }) => {
   await example.expectAutoFocus(name)
   await example.expectNoAutoFocus(bio)
 
-  // Make first field be valid, focus goes to the second field
+  // Make first fields valid, focus goes to bio
   await name.input.fill('John')
+  await email.input.fill('john@example.com')
   await button.click()
   await page.reload()
   await example.expectValid(name)
+  await example.expectValid(email)
   await example.expectAutoFocus(bio)
 
   // Make form be valid and test selecting an option
@@ -101,6 +120,7 @@ testWithoutJS('With JS disabled', async ({ example }) => {
 
   await example.expectData({
     name: 'John',
+    email: 'john@example.com',
     bio: 'My bio',
     roleId: 2,
   })

--- a/apps/web/app/routes/examples/labels-options-etc.tsx
+++ b/apps/web/app/routes/examples/labels-options-etc.tsx
@@ -15,6 +15,7 @@ export const meta: Route.MetaFunction = () => metaTags({ title, description })
 
 const code = `const schema = z.object({
   name: z.string().min(1),
+  email: z.string().min(1).email(),
   roleId: z.number().int(),
   bio: z.string().min(1),
 })
@@ -25,6 +26,7 @@ export default () => (
     autoFocus="name"
     labels={{ roleId: 'Role' }}
     placeholders={{ name: 'Your name', bio: 'Your story' }}
+    autoComplete={{ email: 'email' }}
     options={{
       roleId: [
         { name: 'Designer', value: 1 },
@@ -38,6 +40,7 @@ export default () => (
 
 const schema = z.object({
   name: z.string().min(1),
+  email: z.string().min(1).email(),
   roleId: z.number().int(),
   bio: z.string().min(1),
 })
@@ -59,6 +62,7 @@ export default function Component() {
         autoFocus="name"
         labels={{ roleId: 'Role' }}
         placeholders={{ name: 'Your name', bio: 'Your story' }}
+        autoComplete={{ email: 'email' }}
         options={{
           roleId: [
             { name: 'Designer', value: 1 },

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -392,6 +392,71 @@ describe('SchemaForm', () => {
     expect(html).toContain('autoComplete="organization"')
     expect(html).toContain('autoComplete="shipping"')
   })
+
+  it('applies schema-level autoComplete to generated inputs', () => {
+    const schema = z.object({
+      name: z.string(),
+      email: z.string(),
+      bio: z.string(),
+      role: z.enum(['a', 'b']),
+    })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        autoComplete={{
+          name: 'name',
+          email: 'email',
+          bio: 'on',
+          role: 'organization',
+        }}
+        multiline={['bio']}
+      />
+    )
+
+    expect(html).toContain('autoComplete="name"')
+    expect(html).toContain('autoComplete="email"')
+    expect(html).toContain('autoComplete="on"')
+    expect(html).toContain('autoComplete="organization"')
+  })
+
+  it('passes schema-level autoComplete through renderField', () => {
+    const schema = z.object({ email: z.string() })
+    const renderField: RenderField<
+      typeof schema,
+      // biome-ignore lint/suspicious/noExplicitAny: test helper
+      any,
+      readonly [],
+      readonly []
+    > = vi.fn(({ Field, name, autoComplete }) => (
+      <Field name={name} autoComplete={autoComplete} />
+    ))
+
+    renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        autoComplete={{ email: 'email' }}
+        renderField={renderField}
+      />
+    )
+
+    expect(renderField).toHaveBeenCalledWith(
+      expect.objectContaining({ autoComplete: 'email' })
+    )
+  })
+
+  it('lets Field-level autoComplete override schema-level', () => {
+    const schema = z.object({ email: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} autoComplete={{ email: 'email' }}>
+        {({ Field }) => <Field name="email" autoComplete="off" />}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('autoComplete="off"')
+    expect(html).not.toContain('autoComplete="email"')
+  })
 })
 it('uses provided form component for rendering', () => {
   const schema = z.object({ name: z.string() })

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -189,6 +189,9 @@ type SchemaFormProps<
   values?: FormValues<Infer<Schema>>
   labels?: Partial<Record<keyof Infer<Schema>, string>>
   placeholders?: Partial<Record<keyof Infer<Schema>, string>>
+  autoComplete?: Partial<
+    Record<keyof Infer<Schema>, JSX.IntrinsicElements['input']['autoComplete']>
+  >
   options?: Options<Infer<Schema>>
   emptyOptionLabel?: string
   hiddenFields?: Array<keyof Infer<Schema>>
@@ -209,7 +212,7 @@ type SchemaFormProps<
   >
   idPrefix?: string
   flushSync?: boolean
-} & Omit<ReactRouterFormProps, 'children' | 'autoFocus'>
+} & Omit<ReactRouterFormProps, 'children' | 'autoFocus' | 'autoComplete'>
 
 const formatToInputType: Partial<Record<string, AutoInputType>> = {
   date: 'date',
@@ -284,6 +287,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
     children: childrenFn,
     labels,
     placeholders,
+    autoComplete: autoCompleteProp,
     options,
     inputTypes,
     autoInputTypes = ['date', 'datetime-local', 'time'],
@@ -443,6 +447,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
         multiline: multiline && Boolean(multiline.find((item) => item === key)),
         radio: radio && Boolean(radio.find((item) => item === key)),
         placeholder: placeholders?.[key],
+        autoComplete: autoCompleteProp?.[key],
       } as Field<SchemaType>
     }
 
@@ -679,6 +684,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
  * @param props.children - Custom content instead of the default layout
  * @param props.labels - Custom labels for form fields
  * @param props.placeholders - Placeholder text for fields
+ * @param props.autoComplete - Autocomplete hints for fields
  * @param props.options - Select and radio options for fields
  * @param props.inputTypes - Custom input types per field
  * @param props.autoInputTypes - HTML input types to assign automatically based on schema format. Defaults to `['date', 'datetime-local', 'time']`


### PR DESCRIPTION
## Summary

- Adds a per-field `autoComplete` prop to `SchemaForm` (same pattern as `labels`, `placeholders`, etc.)
- Omits the HTML form-level `autoComplete` from `ReactRouterFormProps` to avoid type conflict
- Adds an `email` field to the labels-options-etc example to demonstrate the new prop

## Test plan

- [x] 3 new unit tests: renders attribute, flows through renderField, Field-level overrides schema-level
- [x] E2E tests updated for labels-options-etc (both JS-enabled and JS-disabled)
- [x] `pnpm run tsc`, `pnpm run lint`, `pnpm run test` all pass