### PR TITLE
Fix button name/value not serialized on client-side submit

### DIFF
--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -58,6 +58,7 @@ export const exampleRouteGroups = {
 }
 
 const testRoutes = [
+  'button-name-value',
   'fetcher-with-other-forms-error',
   'field-with-radio-children',
   'field-with-ref',

--- a/apps/web/app/routes/tests/button-name-value.spec.ts
+++ b/apps/web/app/routes/tests/button-name-value.spec.ts
@@ -1,0 +1,39 @@
+import { test } from 'tests/setup/tests'
+
+const route = '/test-examples/button-name-value'
+
+test('With JS enabled', async ({ example }) => {
+  const { page } = example
+  const nameField = example.field('name')
+  const saveButton = page.locator('form button:has-text("Save")')
+
+  await page.goto(route)
+
+  await nameField.input.fill('John')
+
+  await saveButton.click()
+  await page.waitForLoadState('networkidle')
+
+  await example.expectData({
+    name: 'John',
+    _action: 'save',
+  })
+})
+
+test('Clicking the other button sends its value', async ({ example }) => {
+  const { page } = example
+  const nameField = example.field('name')
+  const deleteButton = page.locator('form button:has-text("Delete")')
+
+  await page.goto(route)
+
+  await nameField.input.fill('John')
+
+  await deleteButton.click()
+  await page.waitForLoadState('networkidle')
+
+  await example.expectData({
+    name: 'John',
+    _action: 'delete',
+  })
+})

--- a/apps/web/app/routes/tests/button-name-value.tsx
+++ b/apps/web/app/routes/tests/button-name-value.tsx
@@ -1,0 +1,47 @@
+import hljs from 'highlight.js/lib/common'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/button-name-value'
+
+const title = 'Button name and value'
+const description =
+  'In this example, we ensure that button name and value are serialized on client-side submit.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const schema = z.object({
+  name: z.string().min(1),
+})
+
+export const loader = () => ({
+  code: hljs.highlight('', { language: 'ts' }).value,
+})
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const formData = await request.formData()
+  const data = Object.fromEntries(formData)
+  return { success: true, data }
+}
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm schema={schema}>
+        {({ Field, Errors, Button }) => (
+          <>
+            <Field name="name" />
+            <Errors />
+            <Button name="_action" value="save">
+              Save
+            </Button>
+            <Button name="_action" value="delete">
+              Delete
+            </Button>
+          </>
+        )}
+      </SchemaForm>
+    </Example>
+  )
+}

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -360,10 +360,11 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
 
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     const onSubmit = (event: any) => {
+      const target = event.currentTarget ?? formRef.current
       form.handleSubmit(() => {
         if (!formRef.current) return
 
-        return submit(formRef.current, {
+        return submit(target, {
           method,
           replace: props.replace,
           preventScrollReset: props.preventScrollReset,


### PR DESCRIPTION
## Summary

- Fixes a regression where button `name`/`value` attributes were not included in client-side form submissions (issue #158)
- The root cause was PR #215 (`57e4a87`, Jul 2023), which changed `submit(event.target)` to `submit(formRef.current)` to fix buttons with child elements — this inadvertently stopped serializing button name/value.
- The fix captures `event.currentTarget` (always the button element, regardless of child elements) before React Hook Form's async `handleSubmit` runs, and passes it to React Router's `submit()` instead of `formRef.current`

## Test plan

- [x] Added Playwright E2E tests (`button-name-value.spec.ts`) that submit a form via two buttons with different `name="_action"` values and assert each value appears in the action data
- [x] All 93 existing tests pass, including `field-with-radio-children` (the scenario that originally prompted the breaking change in PR #215)
- [x] `pnpm run lint`, `pnpm run tsc`, and `pnpm run test` all pass

Closes #158