### PR TITLE
Strip defaultValue/defaultChecked from user-facing children components

### DIFF
--- a/packages/remix-forms/src/component-types.test-d.ts
+++ b/packages/remix-forms/src/component-types.test-d.ts
@@ -1,7 +1,12 @@
 import type * as React from 'react'
 import { expectTypeOf, it } from 'vitest'
 import * as z from 'zod'
-import type { IsBoolean, IsEnum, SmartInputSlot } from './create-field'
+import type {
+  IsBoolean,
+  IsEnum,
+  SmartInputSlot,
+  StripDefaultProps,
+} from './create-field'
 import type {
   ComponentMap,
   DefaultComponents,
@@ -339,4 +344,53 @@ it('SmartInputSlot: boolean always wins over Field-level radio', () => {
     true
   >
   expectTypeOf<Slot>().toEqualTypeOf<'checkbox'>()
+})
+
+// --- StripDefaultProps ---
+
+it('StripDefaultProps removes specified props from a component type', () => {
+  type MyComp = React.ComponentType<{
+    defaultValue?: string
+    name: string
+    id?: string
+  }>
+  type Stripped = StripDefaultProps<MyComp, 'defaultValue'>
+  type Expected = React.ComponentType<{ name: string; id?: string }>
+  expectTypeOf<Stripped>().toEqualTypeOf<Expected>()
+})
+
+it('StripDefaultProps removes defaultValue from resolved Input', () => {
+  type Resolved = ResolveComponents<Record<never, never>>
+  type StrippedInput = StripDefaultProps<Resolved['input'], 'defaultValue'>
+  expectTypeOf<PropsOf<StrippedInput>>().not.toHaveProperty('defaultValue')
+})
+
+it('StripDefaultProps removes defaultValue from resolved Multiline', () => {
+  type Resolved = ResolveComponents<Record<never, never>>
+  type StrippedMultiline = StripDefaultProps<
+    Resolved['multiline'],
+    'defaultValue'
+  >
+  expectTypeOf<PropsOf<StrippedMultiline>>().not.toHaveProperty('defaultValue')
+})
+
+it('StripDefaultProps removes defaultValue from resolved Select', () => {
+  type Resolved = ResolveComponents<Record<never, never>>
+  type StrippedSelect = StripDefaultProps<Resolved['select'], 'defaultValue'>
+  expectTypeOf<PropsOf<StrippedSelect>>().not.toHaveProperty('defaultValue')
+})
+
+it('StripDefaultProps removes defaultChecked from resolved Checkbox', () => {
+  type Resolved = ResolveComponents<Record<never, never>>
+  type StrippedCheckbox = StripDefaultProps<
+    Resolved['checkbox'],
+    'defaultChecked'
+  >
+  expectTypeOf<PropsOf<StrippedCheckbox>>().not.toHaveProperty('defaultChecked')
+})
+
+it('StripDefaultProps removes defaultChecked from resolved Radio', () => {
+  type Resolved = ResolveComponents<Record<never, never>>
+  type StrippedRadio = StripDefaultProps<Resolved['radio'], 'defaultChecked'>
+  expectTypeOf<PropsOf<StrippedRadio>>().not.toHaveProperty('defaultChecked')
 })

--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -532,3 +532,98 @@ describe('element type comparison safety', () => {
     expect(customTextarea?.[0]).not.toContain('name="foo"')
   })
 })
+
+describe('defaultValue/defaultChecked stripping', () => {
+  it('strips defaultValue from Input child props', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" value="correct">
+        {({ Input }) => (
+          // @ts-expect-error defaultValue is stripped from user-facing type
+          <Input defaultValue="wrong" />
+        )}
+      </Field>
+    )
+    expect(html).toContain('value="correct"')
+    expect(html).not.toContain('value="wrong"')
+  })
+
+  it('strips defaultValue from Multiline child props', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" value="correct" multiline>
+        {({ Multiline }) => (
+          // @ts-expect-error defaultValue is stripped from user-facing type
+          <Multiline defaultValue="wrong" />
+        )}
+      </Field>
+    )
+    expect(html).toContain('correct')
+    expect(html).not.toContain('wrong')
+  })
+
+  it('strips defaultValue from Select child props', () => {
+    const html = renderToStaticMarkup(
+      <Field
+        name="foo"
+        label="Foo"
+        value="a"
+        options={[
+          { name: 'A', value: 'a' },
+          { name: 'B', value: 'b' },
+        ]}
+      >
+        {({ Select }) => (
+          // @ts-expect-error defaultValue is stripped from user-facing type
+          <Select defaultValue="b" />
+        )}
+      </Field>
+    )
+    expect(html).toContain('<option value="a" selected="">A</option>')
+    expect(html).not.toContain('<option value="b" selected')
+  })
+
+  it('strips defaultChecked from Checkbox child props', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" fieldType="boolean" value={false}>
+        {({ Checkbox }) => (
+          // @ts-expect-error defaultChecked is stripped from user-facing type
+          <Checkbox defaultChecked={true} />
+        )}
+      </Field>
+    )
+    expect(html).not.toContain('checked')
+  })
+
+  it('strips defaultChecked from Radio child props', () => {
+    const html = renderToStaticMarkup(
+      <ChoiceField
+        name="choice"
+        label="Choice"
+        radio
+        value="a"
+        options={[
+          { name: 'A', value: 'a' },
+          { name: 'B', value: 'b' },
+        ]}
+      >
+        {({ RadioGroup, RadioWrapper, Radio, Label }) => (
+          <RadioGroup>
+            <RadioWrapper>
+              {/* @ts-expect-error defaultChecked is stripped from user-facing type */}
+              <Radio value="a" type="radio" defaultChecked={false} />
+              <Label>A</Label>
+            </RadioWrapper>
+            <RadioWrapper>
+              {/* @ts-expect-error defaultChecked is stripped from user-facing type */}
+              <Radio value="b" type="radio" defaultChecked={true} />
+              <Label>B</Label>
+            </RadioWrapper>
+          </RadioGroup>
+        )}
+      </ChoiceField>
+    )
+    const radioA = html.match(/<input[^>]*value="a"[^>]*/)
+    expect(radioA?.[0]).toContain('checked')
+    const radioB = html.match(/<input[^>]*value="b"[^>]*/)
+    expect(radioB?.[0]).not.toContain('checked')
+  })
+})

--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -4,6 +4,10 @@ import type { UseFormRegister, UseFormRegisterReturn } from 'react-hook-form'
 import { findElement, findParent, mapChildren } from './children-traversal'
 import type { PropsOf } from './defaults'
 import type { FormSchema, Infer } from './prelude'
+
+type StripDefaultProps<C, Keys extends string> = React.ComponentType<
+  Omit<PropsOf<C>, Keys>
+>
 import { mapObject } from './prelude'
 import type { Field } from './schema-form'
 
@@ -28,13 +32,13 @@ type Children<
     SmartInput: React.ComponentType<
       SmartInputProps<Schema, Resolved, Multiline, Radio, Name, M, R>
     >
-    Input: Resolved['input']
-    Multiline: Resolved['multiline']
-    Select: Resolved['select']
-    Checkbox: Resolved['checkbox']
+    Input: StripDefaultProps<Resolved['input'], 'defaultValue'>
+    Multiline: StripDefaultProps<Resolved['multiline'], 'defaultValue'>
+    Select: StripDefaultProps<Resolved['select'], 'defaultValue'>
+    Checkbox: StripDefaultProps<Resolved['checkbox'], 'defaultChecked'>
     RadioGroup: Resolved['radioGroup']
     RadioWrapper: Resolved['radioWrapper']
-    Radio: Resolved['radio']
+    Radio: StripDefaultProps<Resolved['radio'], 'defaultChecked'>
     CheckboxWrapper: Resolved['checkboxWrapper']
     Errors: Resolved['fieldErrors']
     Error: Resolved['error']
@@ -161,8 +165,11 @@ type SmartInputProps<
   M extends boolean | undefined,
   R extends boolean | undefined,
 > = SmartInputBaseProps &
-  Partial<
-    PropsOf<Resolved[SmartInputSlot<Schema, Multiline, Radio, Name, M, R>]>
+  Omit<
+    Partial<
+      PropsOf<Resolved[SmartInputSlot<Schema, Multiline, Radio, Name, M, R>]>
+    >,
+    'defaultValue' | 'defaultChecked'
   >
 
 const FieldContext = React.createContext<
@@ -245,6 +252,12 @@ function createSmartInput(idPrefix: string, components: Record<string, any>) {
   }: SmartInputBaseProps) => {
     if (!registerProps) return null
 
+    const {
+      defaultValue: _dv,
+      defaultChecked: _dc,
+      ...safeProps
+    } = props as Record<string, unknown>
+
     const makeRadioOption =
       (props: Record<string, unknown>, checkedValue: Option['value']) =>
       ({ name, value }: Option) => {
@@ -270,7 +283,7 @@ function createSmartInput(idPrefix: string, components: Record<string, any>) {
       id: `${idPrefix}${name}`,
       autoFocus,
       ...registerProps,
-      ...props,
+      ...safeProps,
     }
 
     const withAutoComplete = { ...commonProps, autoComplete }
@@ -473,12 +486,18 @@ function createField<
               a11yProps,
             }
 
+            const {
+              defaultValue: _sdv,
+              defaultChecked: _sdc,
+              ...smartChildProps
+            } = child.props
             return React.cloneElement(child, {
               ...smartInputProps,
-              ...child.props,
+              ...smartChildProps,
             })
           }
           if (child.type === Input) {
+            const { defaultValue: _, ...inputProps } = child.props
             return React.cloneElement(child, {
               id: `${idPrefix}${String(name)}`,
               type,
@@ -488,11 +507,12 @@ function createField<
               autoFocus,
               autoComplete,
               defaultValue: value,
-              ...child.props,
+              ...inputProps,
               ref: mergedRef,
             })
           }
           if (child.type === Multiline) {
+            const { defaultValue: _, ...multilineProps } = child.props
             return React.cloneElement(child, {
               id: `${idPrefix}${String(name)}`,
               ...registerProps,
@@ -501,11 +521,12 @@ function createField<
               autoFocus,
               autoComplete,
               defaultValue: value,
-              ...child.props,
+              ...multilineProps,
               ref: mergedRef,
             })
           }
           if (child.type === Select) {
+            const { defaultValue: _, ...selectProps } = child.props
             return React.cloneElement(child, {
               id: `${idPrefix}${String(name)}`,
               ...registerProps,
@@ -514,7 +535,7 @@ function createField<
               autoComplete,
               defaultValue: value,
               children: makeOptionComponents(makeSelectOption, options),
-              ...child.props,
+              ...selectProps,
               ref: mergedRef,
             })
           }
@@ -523,6 +544,7 @@ function createField<
             ((child.type as unknown) !== 'input' ||
               child.props.type === 'checkbox')
           ) {
+            const { defaultChecked: _, ...checkboxProps } = child.props
             return React.cloneElement(child, {
               id: `${idPrefix}${String(name)}`,
               type,
@@ -531,7 +553,7 @@ function createField<
               ...a11yProps,
               placeholder,
               defaultChecked: Boolean(value),
-              ...child.props,
+              ...checkboxProps,
               ref: mergedRef,
             })
           }
@@ -546,13 +568,14 @@ function createField<
             ((child.type as unknown) !== 'input' ||
               child.props.type === 'radio')
           ) {
+            const { defaultChecked: _, ...radioProps } = child.props
             return React.cloneElement(child, {
-              id: `${idPrefix}${String(name)}-${child.props.value}`,
+              id: `${idPrefix}${String(name)}-${radioProps.value}`,
               type: 'radio',
               autoFocus,
               ...registerProps,
-              defaultChecked: value === child.props.value,
-              ...child.props,
+              defaultChecked: value === radioProps.value,
+              ...radioProps,
               ref: mergedRef,
             })
           }
@@ -661,6 +684,7 @@ export type {
   FieldComponent,
   Option,
   SmartInputSlot,
+  StripDefaultProps,
   IsBoolean,
   IsEnum,
 }


### PR DESCRIPTION
## Summary

- Strips `defaultValue` from `Input`, `Multiline`, and `Select` components exposed via the children render function
- Strips `defaultChecked` from `Checkbox` and `Radio` components exposed via the children render function
- Strips both from `SmartInput` props and the internal `createSmartInput` rest params
- Adds `StripDefaultProps<C, Keys>` type utility that omits props from a component's type while preserving slot constraints
- Slot prop types in `defaults.tsx` are **unchanged** — custom components must still accept these props since the library passes them internally

RHF manages these values via `register`, so user-supplied `defaultValue`/`defaultChecked` are misleading and can cause bugs like radio buttons ignoring `defaultChecked`.

Closes #168

## Test plan

- [x] 6 type-level tests verify `StripDefaultProps` strips the correct props from each resolved component slot
- [x] 5 runtime tests verify props are actually stripped at render time (with `@ts-expect-error` confirming the type constraint)
- [x] `pnpm run lint` — clean
- [x] `pnpm run tsc` — compiles including DTS build
- [x] `pnpm run test` — 179 tests pass