### PR TITLE
Pass type="hidden" to inputs when Field is hidden

### DIFF
--- a/packages/remix-forms/src/component-types.test-d.ts
+++ b/packages/remix-forms/src/component-types.test-d.ts
@@ -199,7 +199,9 @@ it('SmartInputSlot resolves boolean field to checkbox', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'flag',
+    undefined,
     undefined,
     undefined
   >
@@ -213,7 +215,9 @@ it('SmartInputSlot resolves optional boolean to checkbox', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'flag',
+    undefined,
     undefined,
     undefined
   >
@@ -227,7 +231,9 @@ it('SmartInputSlot resolves string to input', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'name',
+    undefined,
     undefined,
     undefined
   >
@@ -241,7 +247,9 @@ it('SmartInputSlot resolves enum to select', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'role',
+    undefined,
     undefined,
     undefined
   >
@@ -255,7 +263,9 @@ it('SmartInputSlot resolves optional enum to select', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'role',
+    undefined,
     undefined,
     undefined
   >
@@ -269,7 +279,9 @@ it('SmartInputSlot resolves string in config multiline to multiline', () => {
     S,
     readonly ['bio'],
     readonly [],
+    readonly [],
     'bio',
+    undefined,
     undefined,
     undefined
   >
@@ -283,7 +295,9 @@ it('SmartInputSlot resolves enum in config radio to radio', () => {
     S,
     readonly [],
     readonly ['role'],
+    readonly [],
     'role',
+    undefined,
     undefined,
     undefined
   >
@@ -297,8 +311,10 @@ it('SmartInputSlot resolves Field-level multiline=true to multiline', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'notes',
     true,
+    undefined,
     undefined
   >
   expectTypeOf<Slot>().toEqualTypeOf<'multiline'>()
@@ -311,9 +327,11 @@ it('SmartInputSlot resolves Field-level radio=true to radio', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'choice',
     undefined,
-    true
+    true,
+    undefined
   >
   expectTypeOf<Slot>().toEqualTypeOf<'radio'>()
 })
@@ -325,9 +343,11 @@ it('SmartInputSlot: Field-level radio=true overrides config multiline', () => {
     S,
     readonly ['field'],
     readonly [],
+    readonly [],
     'field',
     undefined,
-    true
+    true,
+    undefined
   >
   expectTypeOf<Slot>().toEqualTypeOf<'radio'>()
 })
@@ -339,11 +359,107 @@ it('SmartInputSlot: boolean always wins over Field-level radio', () => {
     S,
     readonly [],
     readonly [],
+    readonly [],
     'flag',
+    undefined,
+    true,
+    undefined
+  >
+  expectTypeOf<Slot>().toEqualTypeOf<'checkbox'>()
+})
+
+it('SmartInputSlot: Field-level hidden=true resolves boolean to input', () => {
+  const schema = z.object({ flag: z.boolean() })
+  type S = typeof schema
+  type Slot = SmartInputSlot<
+    S,
+    readonly [],
+    readonly [],
+    readonly [],
+    'flag',
+    undefined,
     undefined,
     true
   >
-  expectTypeOf<Slot>().toEqualTypeOf<'checkbox'>()
+  expectTypeOf<Slot>().toEqualTypeOf<'input'>()
+})
+
+it('SmartInputSlot: Field-level hidden=true resolves enum to input', () => {
+  const schema = z.object({ role: z.enum(['a', 'b']) })
+  type S = typeof schema
+  type Slot = SmartInputSlot<
+    S,
+    readonly [],
+    readonly [],
+    readonly [],
+    'role',
+    undefined,
+    undefined,
+    true
+  >
+  expectTypeOf<Slot>().toEqualTypeOf<'input'>()
+})
+
+it('SmartInputSlot: schema-level Hidden resolves boolean to input', () => {
+  const schema = z.object({ flag: z.boolean() })
+  type S = typeof schema
+  type Slot = SmartInputSlot<
+    S,
+    readonly [],
+    readonly [],
+    readonly ['flag'],
+    'flag',
+    undefined,
+    undefined,
+    undefined
+  >
+  expectTypeOf<Slot>().toEqualTypeOf<'input'>()
+})
+
+it('SmartInputSlot: schema-level Hidden resolves enum to input', () => {
+  const schema = z.object({ role: z.enum(['a', 'b']) })
+  type S = typeof schema
+  type Slot = SmartInputSlot<
+    S,
+    readonly [],
+    readonly [],
+    readonly ['role'],
+    'role',
+    undefined,
+    undefined,
+    undefined
+  >
+  expectTypeOf<Slot>().toEqualTypeOf<'input'>()
+})
+
+it('SmartInputSlot: schema-level Hidden does not affect other fields', () => {
+  const schema = z.object({
+    secret: z.string(),
+    flag: z.boolean(),
+  })
+  type S = typeof schema
+  type HiddenSlot = SmartInputSlot<
+    S,
+    readonly [],
+    readonly [],
+    readonly ['secret'],
+    'secret',
+    undefined,
+    undefined,
+    undefined
+  >
+  type VisibleSlot = SmartInputSlot<
+    S,
+    readonly [],
+    readonly [],
+    readonly ['secret'],
+    'flag',
+    undefined,
+    undefined,
+    undefined
+  >
+  expectTypeOf<HiddenSlot>().toEqualTypeOf<'input'>()
+  expectTypeOf<VisibleSlot>().toEqualTypeOf<'checkbox'>()
 })
 
 // --- StripDefaultProps ---

--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -19,6 +19,7 @@ const Field = createField<
   typeof schema,
   typeof defaultComponents,
   readonly [],
+  readonly [],
   readonly []
 >({
   register,
@@ -138,6 +139,7 @@ describe('createField', () => {
       typeof schema,
       typeof defaultComponents,
       readonly [],
+      readonly [],
       readonly []
     >({
       register,
@@ -165,6 +167,7 @@ describe('createField', () => {
     const NumField = createField<
       typeof schema,
       typeof defaultComponents,
+      readonly [],
       readonly [],
       readonly []
     >({
@@ -215,12 +218,79 @@ describe('createField', () => {
     expect(html).toContain('<option value="b">B</option>')
   })
 
-  it('applies placeholder and hidden style', () => {
-    const html = renderToStaticMarkup(
-      <Field name="foo" label="Foo" placeholder="Enter" hidden />
-    )
-    expect(html).toContain('placeholder="Enter"')
+  it('applies hidden style and type="hidden" on the input', () => {
+    const html = renderToStaticMarkup(<Field name="foo" label="Foo" hidden />)
     expect(html).toContain('style="display:none"')
+    expect(html).toContain('type="hidden"')
+    expect(html).not.toContain('type="text"')
+  })
+
+  it('renders type="hidden" for boolean fields when hidden', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" fieldType="boolean" hidden />
+    )
+    expect(html).toContain('type="hidden"')
+    expect(html).not.toContain('type="checkbox"')
+  })
+
+  it('renders type="hidden" instead of select when hidden', () => {
+    const html = renderToStaticMarkup(
+      <Field
+        name="foo"
+        label="Foo"
+        options={[
+          { name: 'A', value: 'a' },
+          { name: 'B', value: 'b' },
+        ]}
+        value="a"
+        hidden
+      />
+    )
+    expect(html).toContain('type="hidden"')
+    expect(html).not.toContain('<select')
+  })
+
+  it('renders type="hidden" instead of textarea when hidden and multiline', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" multiline hidden />
+    )
+    expect(html).toContain('type="hidden"')
+    expect(html).not.toContain('<textarea')
+  })
+
+  it('respects explicit type prop over hidden (escape hatch)', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" hidden type="email" />
+    )
+    expect(html).toContain('type="email"')
+    expect(html).not.toContain('type="hidden"')
+  })
+
+  it('passes type="hidden" to SmartInput children when hidden', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" hidden>
+        {({ SmartInput }) => <SmartInput />}
+      </Field>
+    )
+    expect(html).toContain('type="hidden"')
+  })
+
+  it('passes type="hidden" to Input children when hidden', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" hidden>
+        {({ Input }) => <Input />}
+      </Field>
+    )
+    expect(html).toContain('type="hidden"')
+  })
+
+  it('allows SmartInput children to override hidden type (escape hatch)', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" hidden>
+        {({ SmartInput }) => <SmartInput type="text" />}
+      </Field>
+    )
+    expect(html).toContain('type="text"')
   })
 
   it('sets the autoFocus attribute when requested', () => {

--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -21,16 +21,18 @@ type Children<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
   Name extends keyof Infer<Schema>,
   M extends boolean | undefined,
   R extends boolean | undefined,
+  H extends boolean | undefined,
 > = (
   helpers: Omit<Partial<Field<Infer<Schema>>>, 'name'> & {
     name: Name
     type?: JSX.IntrinsicElements['input']['type']
     Label: Resolved['label']
     SmartInput: React.ComponentType<
-      SmartInputProps<Schema, Resolved, Multiline, Radio, Name, M, R>
+      SmartInputProps<Schema, Resolved, Multiline, Radio, Hidden, Name, M, R, H>
     >
     Input: StripDefaultProps<Resolved['input'], 'defaultValue'>
     Multiline: StripDefaultProps<Resolved['multiline'], 'defaultValue'>
@@ -71,15 +73,21 @@ type FieldBaseProps<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
   Name extends keyof Infer<Schema>,
   M extends boolean | undefined,
   R extends boolean | undefined,
-> = Omit<Partial<Field<Infer<Schema>>>, 'name' | 'multiline' | 'radio'> & {
+  H extends boolean | undefined,
+> = Omit<
+  Partial<Field<Infer<Schema>>>,
+  'name' | 'multiline' | 'radio' | 'hidden'
+> & {
   name: Name
   multiline?: M
   radio?: R
+  hidden?: H
   type?: JSX.IntrinsicElements['input']['type']
-  children?: Children<Schema, Resolved, Multiline, Radio, Name, M, R>
+  children?: Children<Schema, Resolved, Multiline, Radio, Hidden, Name, M, R, H>
 }
 
 type FieldProps<
@@ -88,10 +96,12 @@ type FieldProps<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
   Name extends keyof Infer<Schema>,
   M extends boolean | undefined,
   R extends boolean | undefined,
-> = FieldBaseProps<Schema, Resolved, Multiline, Radio, Name, M, R> &
+  H extends boolean | undefined,
+> = FieldBaseProps<Schema, Resolved, Multiline, Radio, Hidden, Name, M, R, H> &
   Omit<JSX.IntrinsicElements['div'], 'children'>
 
 type FieldComponent<
@@ -100,12 +110,14 @@ type FieldComponent<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
 > = <
   Name extends keyof Infer<Schema>,
   const M extends boolean | undefined = undefined,
   const R extends boolean | undefined = undefined,
+  const H extends boolean | undefined = undefined,
 >(
-  props: FieldProps<Schema, Resolved, Multiline, Radio, Name, M, R>
+  props: FieldProps<Schema, Resolved, Multiline, Radio, Hidden, Name, M, R, H>
 ) => React.ReactElement | null
 
 type SmartInputBaseProps = {
@@ -136,24 +148,30 @@ type SmartInputSlot<
   Schema extends FormSchema,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
   Name extends keyof Infer<Schema>,
   M extends boolean | undefined,
   R extends boolean | undefined,
-> = Name extends unknown
-  ? IsBoolean<Infer<Schema>[Name]> extends true
-    ? 'checkbox'
-    : R extends true
-      ? 'radio'
-      : Name extends Radio[number]
-        ? 'radio'
-        : IsEnum<Infer<Schema>[Name]> extends true
-          ? 'select'
-          : M extends true
-            ? 'multiline'
-            : Name extends Multiline[number]
-              ? 'multiline'
-              : 'input'
-  : never
+  H extends boolean | undefined,
+> = H extends true
+  ? 'input'
+  : Name extends unknown
+    ? Name extends Hidden[number]
+      ? 'input'
+      : IsBoolean<Infer<Schema>[Name]> extends true
+        ? 'checkbox'
+        : R extends true
+          ? 'radio'
+          : Name extends Radio[number]
+            ? 'radio'
+            : IsEnum<Infer<Schema>[Name]> extends true
+              ? 'select'
+              : M extends true
+                ? 'multiline'
+                : Name extends Multiline[number]
+                  ? 'multiline'
+                  : 'input'
+    : never
 
 type SmartInputProps<
   Schema extends FormSchema,
@@ -161,13 +179,26 @@ type SmartInputProps<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
   Name extends keyof Infer<Schema>,
   M extends boolean | undefined,
   R extends boolean | undefined,
+  H extends boolean | undefined,
 > = SmartInputBaseProps &
   Omit<
     Partial<
-      PropsOf<Resolved[SmartInputSlot<Schema, Multiline, Radio, Name, M, R>]>
+      PropsOf<
+        Resolved[SmartInputSlot<
+          Schema,
+          Multiline,
+          Radio,
+          Hidden,
+          Name,
+          M,
+          R,
+          H
+        >]
+      >
     >,
     'defaultValue' | 'defaultChecked'
   >
@@ -288,6 +319,10 @@ function createSmartInput(idPrefix: string, components: Record<string, any>) {
 
     const withAutoComplete = { ...commonProps, autoComplete }
 
+    if (type === 'hidden') {
+      return <Input type="hidden" defaultValue={value} {...commonProps} />
+    }
+
     return fieldType === 'boolean' ? (
       <Checkbox
         type="checkbox"
@@ -327,6 +362,7 @@ function createField<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
 >({
   register,
   idPrefix,
@@ -336,7 +372,7 @@ function createField<
   register: UseFormRegister<any>
   idPrefix: string
   components: Resolved
-}): FieldComponent<Schema, Resolved, Multiline, Radio> {
+}): FieldComponent<Schema, Resolved, Multiline, Radio, Hidden> {
   // biome-ignore lint/suspicious/noExplicitAny: widen for internal JSX rendering — generics are for the external API
   const c = components as Record<string, React.ComponentType<any>>
   const Field = c.field
@@ -400,7 +436,8 @@ function createField<
         : undefined
 
       const style = hidden ? { display: 'none' } : undefined
-      const type = typeProp ?? getInputType(fieldType, radio)
+      const type =
+        typeProp ?? (hidden ? 'hidden' : getInputType(fieldType, radio))
 
       const { ref: registerRef, ...registerProps } = register(String(name), {
         setValueAs: (value) => {
@@ -676,7 +713,7 @@ function createField<
         </FieldContext.Provider>
       )
     }
-  ) as unknown as FieldComponent<Schema, Resolved, Multiline, Radio>
+  ) as unknown as FieldComponent<Schema, Resolved, Multiline, Radio, Hidden>
 }
 
 export type {

--- a/packages/remix-forms/src/default-render-field.test.tsx
+++ b/packages/remix-forms/src/default-render-field.test.tsx
@@ -8,8 +8,14 @@ describe('defaultRenderField', () => {
   it('renders the provided Field component with props and key', () => {
     const Field = React.forwardRef<HTMLDivElement, Record<string, unknown>>(
       (props, ref) => <div ref={ref} {...props} />
+    ) as unknown as FieldComponent<
+      FormSchema,
       // biome-ignore lint/suspicious/noExplicitAny: test helper casting
-    ) as unknown as FieldComponent<FormSchema, any, readonly [], readonly []>
+      any,
+      readonly [],
+      readonly [],
+      readonly []
+    >
     // biome-ignore lint/suspicious/noExplicitAny: test helper casting
     const element = (defaultRenderField as any)({
       Field,

--- a/packages/remix-forms/src/default-render-field.tsx
+++ b/packages/remix-forms/src/default-render-field.tsx
@@ -7,11 +7,12 @@ function defaultRenderField<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
 >({
   Field,
   name,
   ...props
-}: RenderFieldProps<Schema, Resolved, Multiline, Radio>) {
+}: RenderFieldProps<Schema, Resolved, Multiline, Radio, Hidden>) {
   return <Field key={String(name)} name={name} {...props} />
 }
 

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -271,6 +271,7 @@ describe('SchemaForm', () => {
     )
 
     expect(html).toMatch(/style="display:none"/)
+    expect(html).toContain('type="hidden"')
   })
 
   it('overrides labels and placeholders', () => {
@@ -329,6 +330,7 @@ describe('SchemaForm', () => {
       typeof schema,
       // biome-ignore lint/suspicious/noExplicitAny: test helper
       any,
+      readonly [],
       readonly [],
       readonly []
     > = vi.fn(({ Field, name, label }) => (
@@ -426,6 +428,7 @@ describe('SchemaForm', () => {
       typeof schema,
       // biome-ignore lint/suspicious/noExplicitAny: test helper
       any,
+      readonly [],
       readonly [],
       readonly []
     > = vi.fn(({ Field, name, autoComplete }) => (

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -92,8 +92,9 @@ type RenderFieldProps<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
 > = Field<Infer<Schema>> & {
-  Field: FieldComponent<Schema, Resolved, Multiline, Radio>
+  Field: FieldComponent<Schema, Resolved, Multiline, Radio, Hidden>
 }
 
 /**
@@ -118,7 +119,10 @@ type RenderField<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
-> = (props: RenderFieldProps<Schema, Resolved, Multiline, Radio>) => JSX.Element
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
+> = (
+  props: RenderFieldProps<Schema, Resolved, Multiline, Radio, Hidden>
+) => JSX.Element
 
 type Options<SchemaType> = Partial<Record<keyof SchemaType, Option[]>>
 
@@ -128,9 +132,10 @@ type Children<
   Resolved extends Record<string, any>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
 > = (
   helpers: {
-    Field: FieldComponent<Schema, Resolved, Multiline, Radio>
+    Field: FieldComponent<Schema, Resolved, Multiline, Radio, Hidden>
     Errors: Resolved['globalErrors']
     Error: Resolved['error']
     Button: Resolved['button']
@@ -167,6 +172,7 @@ type SchemaFormProps<
   Components extends Partial<ComponentMap>,
   Multiline extends ReadonlyArray<keyof Infer<Schema>>,
   Radio extends ReadonlyArray<KeysOfStrings<Infer<Schema>>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
 > = {
   components?: Components
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -180,7 +186,8 @@ type SchemaFormProps<
     Schema,
     MergeComponents<Base, Components>,
     Multiline,
-    Radio
+    Radio,
+    Hidden
   >
   buttonLabel?: string
   pendingButtonLabel?: string
@@ -194,7 +201,7 @@ type SchemaFormProps<
   >
   options?: Options<Infer<Schema>>
   emptyOptionLabel?: string
-  hiddenFields?: Array<keyof Infer<Schema>>
+  hiddenFields?: Hidden
   inputTypes?: Partial<
     Record<keyof Infer<Schema>, React.HTMLInputTypeAttribute>
   >
@@ -208,7 +215,8 @@ type SchemaFormProps<
     Schema,
     MergeComponents<Base, Components>,
     Multiline,
-    Radio
+    Radio,
+    Hidden
   >
   idPrefix?: string
   flushSync?: boolean
@@ -272,6 +280,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
     const Radio extends ReadonlyArray<
       KeysOfStrings<Infer<Schema>>
     > = readonly [],
+    const Hidden extends ReadonlyArray<keyof Infer<Schema>> = readonly [],
   >({
     components: componentsProp,
     fetcher,
@@ -301,7 +310,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
     idPrefix: idPrefixProp,
     flushSync,
     ...props
-  }: SchemaFormProps<Schema, Base, Components, Multiline, Radio>) {
+  }: SchemaFormProps<Schema, Base, Components, Multiline, Radio, Hidden>) {
     type SchemaType = Infer<Schema>
     const generatedId = React.useId()
     const idPrefix = idPrefixProp ?? generatedId
@@ -387,7 +396,8 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
           Schema,
           MergeComponents<Base, Components>,
           Multiline,
-          Radio
+          Radio,
+          Hidden
         >({
           register: form.register,
           idPrefix,


### PR DESCRIPTION
## Summary
- Fixes #227: `<Field hidden />` now renders `<input type="hidden">` instead of keeping the original input type behind `display:none`
- Adds `Hidden` generic (schema-level, mirroring `Multiline`/`Radio`) and `H` generic (field-level, mirroring `M`/`R`) so `SmartInputSlot` resolves to `'input'` for hidden fields — SmartInput accepts input props, not checkbox/select/multiline props
- `hiddenFields` prop is now a generic `ReadonlyArray` for literal type inference (breaking change for v5)
- SmartInput early-returns `<input type="hidden">` for all field types (boolean, select, multiline, radio)
- Escape hatches preserved: explicit `type` prop on Field or SmartInput overrides the hidden default

## Test plan
- [x] `pnpm run tsc` passes
- [x] `pnpm run lint` passes  
- [x] `pnpm run test` passes (186 tests, including 8 new hidden-field runtime tests and 5 new type-level tests)
- [x] Verify E2E hidden field examples still work (`pnpm run test` from root)