### PR TITLE
Infer Field wrapper props from the field component slot

### DIFF
--- a/packages/remix-forms/src/component-types.test-d.ts
+++ b/packages/remix-forms/src/component-types.test-d.ts
@@ -2,6 +2,7 @@ import type * as React from 'react'
 import { expectTypeOf, it } from 'vitest'
 import * as z from 'zod'
 import type {
+  FieldComponent,
   IsBoolean,
   IsEnum,
   SmartInputSlot,
@@ -544,4 +545,54 @@ it('StripDefaultProps removes defaultChecked from resolved Radio', () => {
   type Resolved = ResolveComponents<Record<never, never>>
   type StrippedRadio = StripDefaultProps<Resolved['radio'], 'defaultChecked'>
   expectTypeOf<PropsOf<StrippedRadio>>().not.toHaveProperty('defaultChecked')
+})
+
+// --- FieldComponent wrapper props inference ---
+
+it('PropsOf extracts props from a forwardRef component', () => {
+  type MyRef = React.ForwardRefExoticComponent<
+    React.PropsWithoutRef<{ size: string; color: number }> &
+      React.RefAttributes<HTMLDivElement>
+  >
+  expectTypeOf<PropsOf<MyRef>>().toHaveProperty('size')
+  expectTypeOf<PropsOf<MyRef>>().toHaveProperty('color')
+})
+
+it('FieldComponent with default components accepts field wrapper props', () => {
+  const schema = z.object({ name: z.string() })
+  type S = typeof schema
+  type Resolved = ResolveComponents<Record<never, never>>
+  type FC = FieldComponent<S, Resolved, readonly [], readonly [], readonly []>
+  type Props = Parameters<FC>[0]
+  expectTypeOf<Props>().toHaveProperty('className')
+})
+
+it('FieldComponent with custom field component accepts custom wrapper props', () => {
+  type CustomField = React.FC<{
+    hidden?: boolean
+    style?: React.CSSProperties
+    children?: React.ReactNode
+    variant?: 'outlined' | 'filled'
+  }>
+  const schema = z.object({ name: z.string() })
+  type S = typeof schema
+  type Resolved = MergeComponents<{ field: CustomField }, NoOverrides>
+  type FC = FieldComponent<S, Resolved, readonly [], readonly [], readonly []>
+  type Props = Parameters<FC>[0]
+  expectTypeOf<Props>().toHaveProperty('variant')
+})
+
+it('FieldComponent with custom field component rejects div-only props', () => {
+  type CustomField = React.FC<{
+    hidden?: boolean
+    style?: React.CSSProperties
+    children?: React.ReactNode
+    variant?: 'outlined' | 'filled'
+  }>
+  const schema = z.object({ name: z.string() })
+  type S = typeof schema
+  type Resolved = MergeComponents<{ field: CustomField }, NoOverrides>
+  type FC = FieldComponent<S, Resolved, readonly [], readonly [], readonly []>
+  type Props = Parameters<FC>[0]
+  expectTypeOf<Props>().not.toHaveProperty('className')
 })

--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -102,7 +102,7 @@ type FieldProps<
   R extends boolean | undefined,
   H extends boolean | undefined,
 > = FieldBaseProps<Schema, Resolved, Multiline, Radio, Hidden, Name, M, R, H> &
-  Omit<JSX.IntrinsicElements['div'], 'children'>
+  Omit<PropsOf<Resolved['field']>, 'children'>
 
 type FieldComponent<
   Schema extends FormSchema,

--- a/packages/remix-forms/src/default-render-field.tsx
+++ b/packages/remix-forms/src/default-render-field.tsx
@@ -13,7 +13,8 @@ function defaultRenderField<
   name,
   ...props
 }: RenderFieldProps<Schema, Resolved, Multiline, Radio, Hidden>) {
-  return <Field key={String(name)} name={name} {...props} />
+  // biome-ignore lint/suspicious/noExplicitAny: Resolved is generic here — type safety is enforced at the call site
+  return <Field key={String(name)} name={name} {...(props as any)} />
 }
 
 export { defaultRenderField }


### PR DESCRIPTION
## Summary

- `FieldProps` hardcoded `Omit<JSX.IntrinsicElements['div'], 'children'>` for wrapper props, ignoring that the `field` slot is configurable
- Replace with `Omit<PropsOf<Resolved['field']>, 'children'>` so Field accepts the actual wrapper component's props
- Default behavior unchanged — `DefaultField` is a div, so `PropsOf` resolves to div props
- Custom field components now get correct typing instead of always exposing div props

## Test plan

- [x] `pnpm run tsc` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (195 unit + 93 Playwright)
- [x] New type tests verify: PropsOf with forwardRef, default Field accepts `className`, custom field component accepts custom props, custom field component rejects div-only props