### PR TITLE
Forward all makeField props to Field with custom children

### DIFF
--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -764,6 +764,36 @@ describe('element type comparison safety', () => {
   })
 })
 
+describe('schema-level props forwarded to Field with custom children', () => {
+  it('forwards inputTypes to Field with custom children', () => {
+    const schema = z.object({ email: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} inputTypes={{ email: 'email' }}>
+        {({ Field }) => (
+          <Field name="email">{({ SmartInput }) => <SmartInput />}</Field>
+        )}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('type="email"')
+  })
+
+  it('forwards autoComplete to Field with custom children', () => {
+    const schema = z.object({ email: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} autoComplete={{ email: 'username' }}>
+        {({ Field }) => (
+          <Field name="email">{({ SmartInput }) => <SmartInput />}</Field>
+        )}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('autoComplete="username"')
+  })
+})
+
 describe('SchemaForm hidden field errors', () => {
   it('promotes hidden field errors to global errors', () => {
     const schema = z.object({ visible: z.string(), secret: z.string() })

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -545,17 +545,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
           }
 
           return React.cloneElement(child, {
-            shape: field?.shape,
-            fieldType: field?.fieldType,
-            label: field?.label,
-            placeholder: field?.placeholder,
-            required: field?.required,
-            options: field?.options,
-            value: field?.value,
-            errors: field?.errors,
-            hidden: field?.hidden,
-            multiline: field?.multiline,
-            radio: field?.radio,
+            ...field,
             ...child.props,
             autoFocus,
           })


### PR DESCRIPTION
## Summary

- The `cloneElement` path for Fields with custom children manually listed each prop but missed `type`, `dirty`, and `autoComplete` — the same class of bug PR #402 fixed for `radio`
- Replace with `...field` spread, matching the without-children path and preventing future regressions when new props are added to `makeField`
- Schema-level `inputTypes` and `autoComplete` now correctly reach Fields that use the children render prop

## Test plan

- [x] `pnpm run tsc` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (197 unit + 93 Playwright)
- [x] TDD: two new tests written first (red), then fix applied (green)