### PR TITLE
Add renderForm prop to SchemaForm

### DIFF
--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -50,6 +50,7 @@ export const exampleRouteGroups = {
     'Auto complete',
     'Chakra UI',
   ],
+  renderForm: ['Pending UI', 'Errors first', 'Custom wrapper', 'Global layout'],
   renderField: [
     'Required indicator',
     'Error indicator',

--- a/apps/web/app/routes/examples/custom-wrapper.tsx
+++ b/apps/web/app/routes/examples/custom-wrapper.tsx
@@ -1,0 +1,77 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import { formAction } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/custom-wrapper'
+
+const title = 'Custom wrapper'
+const description =
+  'In this example, we use renderForm to wrap the auto-generated fields in a styled container.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const code = `const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export default () => (
+  <SchemaForm
+    schema={schema}
+    renderForm={({ Fields, Errors, Button }) => (
+      <>
+        <fieldset className="rounded-lg border border-gray-600 p-6">
+          <legend className="px-2 text-sm text-gray-400">
+            Your details
+          </legend>
+          <Fields />
+        </fieldset>
+        <Errors />
+        <Button />
+      </>
+    )}
+  />
+)`
+
+const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export const loader = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm
+        schema={schema}
+        renderForm={({ Fields, Errors, Button }) => (
+          <>
+            <fieldset className="rounded-lg border border-gray-600 p-6">
+              <legend className="px-2 text-gray-400 text-sm">
+                Your details
+              </legend>
+              <Fields />
+            </fieldset>
+            <Errors />
+            <Button />
+          </>
+        )}
+      />
+    </Example>
+  )
+}

--- a/apps/web/app/routes/examples/errors-first.tsx
+++ b/apps/web/app/routes/examples/errors-first.tsx
@@ -1,0 +1,67 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import { formAction } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/errors-first'
+
+const title = 'Errors first'
+const description =
+  'In this example, we use renderForm to place global errors above the fields instead of below them.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const code = `const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export default () => (
+  <SchemaForm
+    schema={schema}
+    renderForm={({ Fields, Errors, Button }) => (
+      <>
+        <Errors />
+        <Fields />
+        <Button />
+      </>
+    )}
+  />
+)`
+
+const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export const loader = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm
+        schema={schema}
+        renderForm={({ Fields, Errors, Button }) => (
+          <>
+            <Errors />
+            <Fields />
+            <Button />
+          </>
+        )}
+      />
+    </Example>
+  )
+}

--- a/apps/web/app/routes/examples/global-layout.tsx
+++ b/apps/web/app/routes/examples/global-layout.tsx
@@ -1,0 +1,117 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import * as React from 'react'
+import { Form, useNavigation } from 'react-router'
+import { formAction, makeSchemaForm } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Checkbox from '~/ui/checkbox'
+import CheckboxLabel from '~/ui/checkbox-label'
+import Error from '~/ui/error'
+import Errors from '~/ui/errors'
+import Example from '~/ui/example'
+import Field from '~/ui/field'
+import Fields from '~/ui/fields'
+import Input from '~/ui/input'
+import Label from '~/ui/label'
+import Radio from '~/ui/radio'
+import RadioGroup from '~/ui/radio-group'
+import RadioLabel from '~/ui/radio-label'
+import Select from '~/ui/select'
+import SubmitButton from '~/ui/submit-button'
+import TextArea from '~/ui/text-area'
+import type { Route } from './+types/global-layout'
+
+const title = 'Global layout'
+const description =
+  'In this example, we use makeSchemaForm to set a global renderForm layout with inverted colors that applies to all forms created with this factory.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const code = `const SchemaForm = makeSchemaForm(
+  { /* your custom components */ },
+  {
+    renderForm: ({ Fields, Errors, Button, buttonLabel, disabled }) => {
+      const navigation = useNavigation()
+      const pending = navigation.state !== 'idle'
+
+      return (
+        <div className="rounded-box bg-base-100 p-8 shadow-lg invert">
+          <Fields />
+          <Errors />
+          <Button disabled={disabled}>
+            {pending ? 'Submitting...' : buttonLabel}
+          </Button>
+        </div>
+      )
+    },
+  }
+)
+
+// Every form now gets the custom layout automatically
+<SchemaForm schema={schema} />`
+
+const StyledForm = React.forwardRef<
+  HTMLFormElement,
+  React.ComponentPropsWithRef<typeof Form>
+>((props, ref) => <Form ref={ref} className="flex flex-col gap-6" {...props} />)
+
+const GlobalSchemaForm = makeSchemaForm(
+  {
+    form: StyledForm,
+    fields: Fields,
+    field: Field,
+    label: Label,
+    input: Input,
+    multiline: TextArea,
+    select: Select,
+    radio: Radio,
+    radioGroup: RadioGroup,
+    radioLabel: RadioLabel,
+    checkboxLabel: CheckboxLabel,
+    checkbox: Checkbox,
+    button: SubmitButton,
+    globalErrors: Errors,
+    error: Error,
+  },
+  {
+    renderForm: ({ Fields, Errors, Button, buttonLabel, disabled }) => {
+      const navigation = useNavigation()
+      const pending = navigation.state !== 'idle'
+
+      return (
+        <div className="rounded-box bg-base-100 p-8 shadow-lg invert">
+          <Fields />
+          <Errors />
+          <Button disabled={disabled}>
+            {pending ? 'Submitting...' : buttonLabel}
+          </Button>
+        </div>
+      )
+    },
+  }
+)
+
+const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export const loader = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <GlobalSchemaForm schema={schema} />
+    </Example>
+  )
+}

--- a/apps/web/app/routes/examples/pending-ui.tsx
+++ b/apps/web/app/routes/examples/pending-ui.tsx
@@ -1,0 +1,82 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import { useNavigation } from 'react-router'
+import { formAction } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/pending-ui'
+
+const title = 'Pending UI'
+const description =
+  'In this example, we use renderForm to show a loading indicator on the submit button while the form is being submitted.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const code = `const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export default () => (
+  <SchemaForm
+    schema={schema}
+    renderForm={({ Fields, Errors, Button, buttonLabel, disabled }) => {
+      const navigation = useNavigation()
+      const pending = navigation.state !== 'idle'
+
+      return (
+        <>
+          <Fields />
+          <Errors />
+          <Button disabled={disabled}>
+            {pending ? 'Submitting...' : buttonLabel}
+          </Button>
+        </>
+      )
+    }}
+  />
+)`
+
+const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export const loader = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm
+        schema={schema}
+        renderForm={({ Fields, Errors, Button, buttonLabel, disabled }) => {
+          const navigation = useNavigation()
+          const pending = navigation.state !== 'idle'
+
+          return (
+            <>
+              <Fields />
+              <Errors />
+              <Button disabled={disabled}>
+                {pending ? 'Submitting...' : buttonLabel}
+              </Button>
+            </>
+          )
+        }}
+      />
+    </Example>
+  )
+}

--- a/packages/remix-forms/src/component-types.test-d.ts
+++ b/packages/remix-forms/src/component-types.test-d.ts
@@ -17,6 +17,7 @@ import type {
   ResolveComponents,
 } from './defaults'
 import { defaultComponents } from './defaults'
+import type { RenderFormProps, SchemaFormProps } from './schema-form'
 
 it('PropsOf extracts props from a React component', () => {
   type MyProps = { size: string; color: number }
@@ -631,4 +632,58 @@ it('fieldProps with custom field component accepts custom wrapper props', () => 
   type FieldPropsType = NonNullable<Props['fieldProps']>
   expectTypeOf<FieldPropsType>().toHaveProperty('variant')
   expectTypeOf<FieldPropsType>().not.toHaveProperty('className')
+})
+
+// --- RenderForm ---
+
+it('SchemaFormProps accepts optional renderForm', () => {
+  const schema = z.object({ name: z.string() })
+  type Props = SchemaFormProps<
+    typeof schema,
+    Record<never, never>,
+    Record<never, never>,
+    readonly [],
+    readonly [],
+    readonly []
+  >
+  expectTypeOf<Props>().toHaveProperty('renderForm')
+})
+
+it('RenderFormProps includes fetcher, disabled, and buttonLabel', () => {
+  const schema = z.object({ name: z.string() })
+  type S = typeof schema
+  type Resolved = ResolveComponents<Record<never, never>>
+  type Props = RenderFormProps<
+    S,
+    Resolved,
+    readonly [],
+    readonly [],
+    readonly []
+  >
+  expectTypeOf<Props>().toHaveProperty('fetcher')
+  expectTypeOf<Props>().toHaveProperty('disabled')
+  expectTypeOf<Props>().toHaveProperty('buttonLabel')
+  expectTypeOf<Props['disabled']>().toBeBoolean()
+  expectTypeOf<Props['buttonLabel']>().toBeString()
+})
+
+it('RenderFormProps includes component helpers and useFormReturn', () => {
+  const schema = z.object({ name: z.string() })
+  type S = typeof schema
+  type Resolved = ResolveComponents<Record<never, never>>
+  type Props = RenderFormProps<
+    S,
+    Resolved,
+    readonly [],
+    readonly [],
+    readonly []
+  >
+  expectTypeOf<Props>().toHaveProperty('Field')
+  expectTypeOf<Props>().toHaveProperty('Fields')
+  expectTypeOf<Props>().toHaveProperty('Errors')
+  expectTypeOf<Props>().toHaveProperty('Error')
+  expectTypeOf<Props>().toHaveProperty('Button')
+  expectTypeOf<Props>().toHaveProperty('submit')
+  expectTypeOf<Props>().toHaveProperty('register')
+  expectTypeOf<Props>().toHaveProperty('formState')
 })

--- a/packages/remix-forms/src/default-render-form.tsx
+++ b/packages/remix-forms/src/default-render-form.tsx
@@ -1,0 +1,25 @@
+import type { FormSchema, Infer } from './prelude'
+import type { RenderFormProps } from './schema-form'
+
+function defaultRenderForm<
+  Schema extends FormSchema,
+  // biome-ignore lint/suspicious/noExplicitAny: resolved map varies per call site
+  Resolved extends Record<string, any>,
+  Multiline extends ReadonlyArray<keyof Infer<Schema>>,
+  Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
+>({
+  Fields,
+  Errors,
+  Button,
+}: RenderFormProps<Schema, Resolved, Multiline, Radio, Hidden>) {
+  return (
+    <>
+      <Fields />
+      <Errors />
+      <Button />
+    </>
+  )
+}
+
+export { defaultRenderForm }

--- a/packages/remix-forms/src/index.ts
+++ b/packages/remix-forms/src/index.ts
@@ -7,6 +7,8 @@ export type {
   SchemaFormProps,
   RenderFieldProps,
   RenderField,
+  RenderFormProps,
+  RenderForm,
   FormSchema,
 } from './schema-form'
 

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -15,7 +15,8 @@ import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { Form as ReactRouterForm } from 'react-router'
 import * as z from 'zod'
-import { SchemaForm } from './schema-form'
+import { defaultComponents } from './defaults'
+import { SchemaForm, makeSchemaForm } from './schema-form'
 import type { RenderField } from './schema-form'
 
 import { useActionData, useNavigation } from 'react-router'
@@ -1072,5 +1073,235 @@ describe('Fields component', () => {
 
     expect(html).toContain('data-fields-wrapper="true"')
     expect(html).toContain('class="grid-cols-2"')
+  })
+})
+
+describe('renderForm', () => {
+  it('is called when no children are provided', () => {
+    const schema = z.object({ name: z.string() })
+    const renderForm = vi.fn(({ Fields, Errors, Button }) => (
+      <>
+        <Fields />
+        <Errors />
+        <Button />
+      </>
+    ))
+
+    renderToStaticMarkup(<SchemaForm schema={schema} renderForm={renderForm} />)
+
+    expect(renderForm).toHaveBeenCalledTimes(1)
+  })
+
+  it('is ignored when children are provided', () => {
+    const schema = z.object({ name: z.string() })
+    const renderForm = vi.fn(() => null)
+
+    renderToStaticMarkup(
+      <SchemaForm schema={schema} renderForm={renderForm}>
+        {({ Field, Button }) => (
+          <>
+            <Field name="name" />
+            <Button />
+          </>
+        )}
+      </SchemaForm>
+    )
+
+    expect(renderForm).not.toHaveBeenCalled()
+  })
+
+  it('receives fetcher, disabled, and buttonLabel', () => {
+    const schema = z.object({ name: z.string() })
+    const fetcher = {
+      submit: vi.fn(),
+      state: 'idle',
+      Form: (props: React.FormHTMLAttributes<HTMLFormElement>) => (
+        <form {...props} />
+      ),
+    }
+
+    const renderForm = vi.fn(
+      ({
+        Fields,
+        Errors,
+        Button,
+        fetcher: f,
+        disabled: d,
+        buttonLabel: bl,
+      }) => {
+        expect(f).toBe(fetcher)
+        expect(typeof d).toBe('boolean')
+        expect(bl).toBe('Send')
+        return (
+          <>
+            <Fields />
+            <Errors />
+            <Button />
+          </>
+        )
+      }
+    )
+
+    renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        fetcher={fetcher as never}
+        buttonLabel="Send"
+        renderForm={renderForm}
+      />
+    )
+
+    expect(renderForm).toHaveBeenCalled()
+  })
+
+  it('processes Field, Errors, and Button through mapChildren', () => {
+    const schema = z.object({ name: z.string(), email: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        errors={{ _global: ['Oops'] }}
+        buttonLabel="Submit"
+        renderForm={({ Field, Errors, Button }) => (
+          <div data-custom>
+            <Field name="email" />
+            <Field name="name" />
+            <Errors />
+            <Button />
+          </div>
+        )}
+      />
+    )
+
+    expect(html).toContain('data-custom')
+    expect(html).toContain('name="email"')
+    expect(html).toContain('name="name"')
+    expect(html).toContain('Oops')
+    expect(html).toContain('role="alert"')
+    expect(html).toMatch(/<button[^>]*>Submit<\/button>/)
+  })
+
+  it('supports Fields sentinel for auto-rendering', () => {
+    const schema = z.object({ name: z.string(), email: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        renderForm={({ Fields, Errors, Button }) => (
+          <>
+            <Fields />
+            <Errors />
+            <Button />
+          </>
+        )}
+      />
+    )
+
+    expect(html).toContain('name="name"')
+    expect(html).toContain('name="email"')
+    expect(html).toContain('Name')
+    expect(html).toContain('Email')
+  })
+
+  it('receives useFormReturn properties', () => {
+    const schema = z.object({ name: z.string() })
+
+    const renderForm = vi.fn((props) => {
+      expect(props.register).toBeDefined()
+      expect(props.formState).toBeDefined()
+      expect(props.getValues).toBeDefined()
+      return (
+        <>
+          <props.Fields />
+          <props.Errors />
+          <props.Button />
+        </>
+      )
+    })
+
+    renderToStaticMarkup(<SchemaForm schema={schema} renderForm={renderForm} />)
+
+    expect(renderForm).toHaveBeenCalled()
+  })
+
+  it('works with makeSchemaForm factory-level renderForm', () => {
+    const CustomSchemaForm = makeSchemaForm(defaultComponents, {
+      renderForm: ({ Fields, Errors, Button }) => (
+        <div data-factory>
+          <Fields />
+          <Errors />
+          <Button />
+        </div>
+      ),
+    })
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(<CustomSchemaForm schema={schema} />)
+
+    expect(html).toContain('data-factory')
+    expect(html).toContain('name="name"')
+  })
+
+  it('per-form renderForm overrides factory-level', () => {
+    const CustomSchemaForm = makeSchemaForm(defaultComponents, {
+      renderForm: ({ Fields, Errors, Button }) => (
+        <div data-factory>
+          <Fields />
+          <Errors />
+          <Button />
+        </div>
+      ),
+    })
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(
+      <CustomSchemaForm
+        schema={schema}
+        renderForm={({ Fields, Errors, Button }) => (
+          <div data-per-form>
+            <Fields />
+            <Errors />
+            <Button />
+          </div>
+        )}
+      />
+    )
+
+    expect(html).toContain('data-per-form')
+    expect(html).not.toContain('data-factory')
+  })
+
+  it('uses pendingButtonLabel in buttonLabel when submitting', () => {
+    const schema = z.object({ name: z.string() })
+    const fetcher = {
+      submit: vi.fn(),
+      state: 'submitting',
+      Form: (props: React.FormHTMLAttributes<HTMLFormElement>) => (
+        <form {...props} />
+      ),
+    }
+
+    const renderForm = vi.fn(({ Fields, Errors, Button, buttonLabel }) => {
+      expect(buttonLabel).toBe('Sending')
+      return (
+        <>
+          <Fields />
+          <Errors />
+          <Button />
+        </>
+      )
+    })
+
+    renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        fetcher={fetcher as never}
+        buttonLabel="Submit"
+        pendingButtonLabel="Sending"
+        renderForm={renderForm}
+      />
+    )
+
+    expect(renderForm).toHaveBeenCalled()
   })
 })

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -22,11 +22,13 @@ import { mapChildren, reduceElements } from './children-traversal'
 import type { FieldComponent, FieldType, Option } from './create-field'
 import { createField } from './create-field'
 import { defaultRenderField } from './default-render-field'
+import { defaultRenderForm } from './default-render-form'
 import type {
   ComponentMap,
   MergeComponents,
   NoOverrides,
   ReactRouterFormProps,
+  ResolveComponents,
 } from './defaults'
 import { defaultComponents } from './defaults'
 import { FieldsSentinel, expandFieldsSentinel } from './fields-sentinel'
@@ -125,6 +127,78 @@ type RenderField<
   props: RenderFieldProps<Schema, Resolved, Multiline, Radio, Hidden>
 ) => JSX.Element
 
+/**
+ * Props passed to a custom form rendering function.
+ *
+ * Extends the same helpers available via the `children` render prop with
+ * extra context about the form's current state: the `fetcher` instance,
+ * the computed `disabled` flag and the resolved `buttonLabel`.
+ *
+ * @example
+ * ```tsx
+ * const myRenderForm = ({ Fields, Errors, Button }) => (
+ *   <>
+ *     <Fields />
+ *     <Errors />
+ *     <Button />
+ *   </>
+ * )
+ * ```
+ */
+type RenderFormProps<
+  Schema extends FormSchema,
+  // biome-ignore lint/suspicious/noExplicitAny: resolved map varies per call site
+  Resolved extends Record<string, any>,
+  Multiline extends ReadonlyArray<keyof Infer<Schema>>,
+  Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
+> = {
+  Field: FieldComponent<Schema, Resolved, Multiline, Radio, Hidden>
+  Fields: Resolved['fields']
+  Errors: Resolved['globalErrors']
+  Error: Resolved['error']
+  Button: Resolved['button']
+  submit: () => void
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  fetcher: FetcherWithComponents<any> | undefined
+  disabled: boolean
+  buttonLabel: string
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+} & UseFormReturn<Infer<Schema>, any>
+
+/**
+ * Function signature used for rendering the form layout.
+ *
+ * Called when no explicit `children` prop is provided. Can be set globally
+ * via {@link makeSchemaForm} so all forms share the same layout, or
+ * per-form via the `renderForm` prop on {@link SchemaForm}.
+ *
+ * The output goes through the same processing pipeline as `children`:
+ * `Fields` auto-renders all schema fields, `Errors` receives error
+ * messages, and `Button` gets `disabled` and label injected.
+ *
+ * @example
+ * ```tsx
+ * const renderForm = ({ Fields, Errors, Button }) => (
+ *   <>
+ *     <Fields />
+ *     <Errors />
+ *     <Button />
+ *   </>
+ * )
+ * ```
+ */
+type RenderForm<
+  Schema extends FormSchema,
+  // biome-ignore lint/suspicious/noExplicitAny: resolved map varies per call site
+  Resolved extends Record<string, any>,
+  Multiline extends ReadonlyArray<keyof Infer<Schema>>,
+  Radio extends ReadonlyArray<keyof Infer<Schema>>,
+  Hidden extends ReadonlyArray<keyof Infer<Schema>>,
+> = (
+  props: RenderFormProps<Schema, Resolved, Multiline, Radio, Hidden>
+) => React.ReactNode
+
 type Options<SchemaType> = Partial<Record<keyof SchemaType, Option[]>>
 
 type Children<
@@ -185,6 +259,13 @@ type SchemaFormProps<
     'onBlur' | 'onChange' | 'onSubmit'
   >
   renderField?: RenderField<
+    Schema,
+    MergeComponents<Base, Components>,
+    Multiline,
+    Radio,
+    Hidden
+  >
+  renderForm?: RenderForm<
     Schema,
     MergeComponents<Base, Components>,
     Multiline,
@@ -256,6 +337,10 @@ function uiFieldType(info: SchemaInfo): FieldType {
  *
  * @param base - Partial component map providing base-level defaults.
  *   Unspecified slots fall back to the built-in defaults.
+ * @param options - Optional configuration for the factory.
+ * @param options.renderForm - Default form layout function used when no
+ *   `children` or per-form `renderForm` is provided. Receives the same
+ *   helpers as `children` plus `fetcher`, `disabled` and `buttonLabel`.
  * @returns A SchemaForm component that uses the provided base components.
  *
  * @example
@@ -267,8 +352,36 @@ function uiFieldType(info: SchemaInfo): FieldType {
  *   button: MyButton,
  * })
  * ```
+ *
+ * @example
+ * ```tsx
+ * const SchemaForm = makeSchemaForm(
+ *   { input: MyInput },
+ *   {
+ *     renderForm: ({ Fields, Errors, Button }) => (
+ *       <>
+ *         <Fields />
+ *         <Errors />
+ *         <Button />
+ *       </>
+ *     ),
+ *   }
+ * )
+ * ```
  */
-function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
+function makeSchemaForm<Base extends Partial<ComponentMap>>(
+  base: Base,
+  options?: {
+    renderForm?: RenderForm<
+      FormSchema,
+      ResolveComponents<Base>,
+      readonly never[],
+      readonly never[],
+      readonly never[]
+    >
+  }
+) {
+  const factoryRenderForm = options?.renderForm
   const mergedBase = { ...defaultComponents, ...base } as Record<
     string,
     // biome-ignore lint/suspicious/noExplicitAny: widen for internal JSX rendering — generics are for the external API
@@ -289,6 +402,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
     mode = 'onSubmit',
     reValidateMode = 'onChange',
     renderField = defaultRenderField,
+    renderForm: renderFormProp,
     buttonLabel: rawButtonLabel = 'OK',
     pendingButtonLabel,
     method = 'POST',
@@ -518,28 +632,44 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
     const globalErrorsToDisplay =
       navigationState !== 'idle' ? undefined : globalErrors
 
+    const effectiveRenderForm =
+      // biome-ignore lint/suspicious/noExplicitAny: factory-level renderForm uses widened generics — type safety is enforced at the consumer level
+      renderFormProp ?? (factoryRenderForm as any) ?? defaultRenderForm
+
+    const childrenHelpers = {
+      Field,
+      Fields: FieldsSentinel,
+      Errors,
+      Error,
+      Button,
+      submit: doSubmit,
+      ...form,
+    }
+
     const rawChildren =
       // biome-ignore lint/suspicious/noExplicitAny: type safety is enforced on the consumer side via SchemaFormProps
       (childrenFn as ((...args: any[]) => React.ReactNode) | undefined)?.({
-        Field,
-        Fields: FieldsSentinel,
-        Errors,
-        Error,
-        Button,
-        submit: doSubmit,
-        ...form,
+        ...childrenHelpers,
       })
 
-    const expandedChildren = rawChildren
-      ? expandFieldsSentinel(rawChildren, {
-          sentinelType: FieldsSentinel,
-          fieldIdentity: Field,
-          schemaKeys: Object.keys(fields),
-          FieldsWrapper,
-        })
-      : rawChildren
+    const rawContent =
+      rawChildren ??
+      // biome-ignore lint/suspicious/noExplicitAny: type safety is enforced on the consumer side via SchemaFormProps
+      (effectiveRenderForm as (...args: any[]) => React.ReactNode)({
+        ...childrenHelpers,
+        fetcher,
+        disabled,
+        buttonLabel,
+      })
 
-    const customChildren = mapChildren(expandedChildren, (child) => {
+    const expandedContent = expandFieldsSentinel(rawContent, {
+      sentinelType: FieldsSentinel,
+      fieldIdentity: Field,
+      schemaKeys: Object.keys(fields),
+      FieldsWrapper,
+    })
+
+    const processedContent = mapChildren(expandedContent, (child) => {
       if (child.type === Field) {
         const { name } = child.props
         const field = makeField(name)
@@ -596,24 +726,6 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
       return child
     })
 
-    const defaultChildren = () => (
-      <>
-        <FieldsWrapper>
-          {Object.keys(fields)
-            .map(makeField)
-            .map((field) => renderField({ Field, ...field }))}
-        </FieldsWrapper>
-        {globalErrorsToDisplay?.length && (
-          <Errors role="alert">
-            {globalErrorsToDisplay.map((error) => (
-              <Error key={error}>{error}</Error>
-            ))}
-          </Errors>
-        )}
-        <Button disabled={disabled}>{buttonLabel}</Button>
-      </>
-    )
-
     React.useEffect(() => {
       const submitting = navigationState !== 'idle'
 
@@ -627,7 +739,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
 
     React.useEffect(() => {
       const newDefaults = Object.fromEntries(
-        reduceElements(customChildren, [] as string[][], (prev, child) => {
+        reduceElements(processedContent, [] as string[][], (prev, child) => {
           if (child.type === Field) {
             const { name, value } = child.props
             prev.push([name, value])
@@ -666,7 +778,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
           {...props}
         >
           {beforeChildren}
-          {customChildren ?? defaultChildren()}
+          {processedContent}
         </FormComponent>
       </FormProvider>
     )
@@ -687,6 +799,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(base: Base) {
  * @param props.mode - Validation trigger mode for React Hook Form
  * @param props.reValidateMode - Validation mode after submission
  * @param props.renderField - Custom field rendering function
+ * @param props.renderForm - Custom form layout function. Called when no `children` is provided. Receives the same helpers as `children` plus `fetcher`, `disabled` and `buttonLabel`. Can also be set globally via `makeSchemaForm`
  * @param props.buttonLabel - Text shown in the submit button
  * @param props.pendingButtonLabel - Text shown while submitting
  * @param props.method - HTTP method used to submit the form
@@ -743,6 +856,8 @@ export type {
   Field,
   RenderFieldProps,
   RenderField,
+  RenderFormProps,
+  RenderForm,
   SchemaFormProps,
   FormSchema,
 }


### PR DESCRIPTION
## Summary

Closes #122. Adds a `renderForm` prop that customizes the default form layout when no `children` are provided, following the same pattern as `renderField`.

- **`renderForm` prop on `SchemaForm`** — called when no `children` is provided. Receives the same helpers as `children` (`Field`, `Fields`, `Errors`, `Error`, `Button`, `submit`, `...useFormReturn`) plus extra context: `fetcher`, `disabled`, and `buttonLabel`.
- **Factory-level `renderForm` via `makeSchemaForm`** — set a global layout for all forms created with the factory. Per-form `renderForm` overrides factory-level.
- **`defaultRenderForm`** — follows the `defaultRenderField` pattern. Renders `<Fields /> <Errors /> <Button />`.
- **Unified rendering pipeline** — removed `defaultChildren()`. Both `children` and `renderForm` now go through the same `expandFieldsSentinel` + `mapChildren` processing.
- **4 website examples**: Pending UI, Errors first, Custom wrapper, Global layout.

### Priority

`children` > per-form `renderForm` > factory-level `renderForm` > `defaultRenderForm`

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run tsc` passes
- [x] `pnpm run test` passes (228 unit + 95 E2E)
- [x] Verify website examples render correctly at `/examples/render-form/*`