### PR TITLE
Add renderField to makeSchemaForm options

### DIFF
--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -56,6 +56,7 @@ export const exampleRouteGroups = {
     'Error indicator',
     'Dirty indicator',
     'Inline checkboxes',
+    'Global render field',
   ],
 }
 

--- a/apps/web/app/routes/examples/global-render-field.spec.ts
+++ b/apps/web/app/routes/examples/global-render-field.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/render-field/global-render-field'
+
+test('With JS enabled', async ({ example }) => {
+  const { firstName, email, button, page } = example
+  const preferredSport = example.field('preferredSport')
+  const newsletter = example.field('newsletter')
+
+  await page.goto(route)
+
+  // Render
+  await example.expectField(email)
+  await example.expectField(firstName)
+  await example.expectSelect(preferredSport, { value: '' })
+  const options = preferredSport.input.locator('option')
+  await expect(options.first()).toHaveText('Basketball')
+  await expect(options.nth(1)).toHaveText('Football')
+  await expect(options.last()).toHaveText('Other')
+  await expect(button).toBeEnabled()
+  await example.expectField(newsletter, { type: 'checkbox', value: 'on' })
+
+  // Client-side validation
+  await button.click()
+
+  // Show field errors and focus on the first field
+  await example.expectError(email, 'Invalid email address')
+
+  await example.expectError(
+    firstName,
+    'Too small: expected string to have >=1 characters'
+  )
+
+  const errorClass = 'input-error'
+
+  expect(await email.input.getAttribute('class')).toContain(errorClass)
+  expect(await firstName.input.getAttribute('class')).toContain(errorClass)
+  await expect(email.input).toBeFocused()
+
+  // Make first field valid and focus on the next one
+  await email.input.fill('john@doe.com')
+  await example.expectValid(email)
+  await button.click()
+  await expect(firstName.input).toBeFocused()
+
+  // Make form be valid
+  await firstName.input.fill('John')
+  await preferredSport.input.selectOption('Other')
+  await newsletter.input.check()
+  await example.expectValid(firstName)
+  await example.expectValid(preferredSport)
+  await example.expectValid(newsletter)
+
+  expect(await email.input.getAttribute('class')).not.toContain(errorClass)
+  expect(await firstName.input.getAttribute('class')).not.toContain(errorClass)
+
+  // Submit form
+  await button.click()
+  await expect(button).toBeDisabled()
+
+  await example.expectData({
+    email: 'john@doe.com',
+    firstName: 'John',
+    preferredSport: 'Other',
+    newsletter: true,
+  })
+})
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { firstName, email, button, page } = example
+  const preferredSport = example.field('preferredSport')
+  const newsletter = example.field('newsletter')
+
+  await page.goto(route)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectError(email, 'Invalid email address')
+  await example.expectAutoFocus(email)
+
+  // Make form be valid
+  await email.input.fill('john@doe.com')
+  await firstName.input.fill('John')
+  await preferredSport.input.selectOption('Other')
+  await newsletter.input.check()
+
+  // Submit form
+  await button.click()
+  await page.reload()
+  await example.expectValid(email)
+  await example.expectValid(firstName)
+  await example.expectValid(preferredSport)
+  await example.expectValid(newsletter)
+
+  await example.expectData({
+    email: 'john@doe.com',
+    firstName: 'John',
+    preferredSport: 'Other',
+    newsletter: true,
+  })
+})

--- a/apps/web/app/routes/examples/global-render-field.tsx
+++ b/apps/web/app/routes/examples/global-render-field.tsx
@@ -1,0 +1,121 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import * as React from 'react'
+import { Form } from 'react-router'
+import { formAction, makeSchemaForm } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Checkbox from '~/ui/checkbox'
+import CheckboxLabel from '~/ui/checkbox-label'
+import Error from '~/ui/error'
+import Errors from '~/ui/errors'
+import Example from '~/ui/example'
+import Field from '~/ui/field'
+import Fields from '~/ui/fields'
+import Input from '~/ui/input'
+import Label from '~/ui/label'
+import Radio from '~/ui/radio'
+import RadioGroup from '~/ui/radio-group'
+import RadioLabel from '~/ui/radio-label'
+import Select from '~/ui/select'
+import SubmitButton from '~/ui/submit-button'
+import TextArea from '~/ui/text-area'
+import type { Route } from './+types/global-render-field'
+
+const title = 'Global render field'
+const description =
+  'In this example, we use makeSchemaForm with a renderField option to globally customize how every field is rendered. Labels turn red when a field has errors.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const code = `const SchemaForm = makeSchemaForm(
+  { /* your custom components */ },
+  {
+    renderField: ({ Field, ...props }) => {
+      const { name, errors } = props
+
+      return (
+        <Field key={name} {...props}>
+          {({ Label, SmartInput, Errors }) => (
+            <>
+              <Label className={errors ? 'text-error' : undefined} />
+              <SmartInput
+                className={errors ? 'input-error' : undefined}
+              />
+              <Errors />
+            </>
+          )}
+        </Field>
+      )
+    },
+  }
+)
+
+// Every form now gets the custom field rendering automatically
+<SchemaForm schema={schema} />`
+
+const StyledForm = React.forwardRef<
+  HTMLFormElement,
+  React.ComponentPropsWithRef<typeof Form>
+>((props, ref) => <Form ref={ref} className="flex flex-col gap-6" {...props} />)
+
+const GlobalSchemaForm = makeSchemaForm(
+  {
+    form: StyledForm,
+    fields: Fields,
+    field: Field,
+    label: Label,
+    input: Input,
+    multiline: TextArea,
+    select: Select,
+    radio: Radio,
+    radioGroup: RadioGroup,
+    radioLabel: RadioLabel,
+    checkboxLabel: CheckboxLabel,
+    checkbox: Checkbox,
+    button: SubmitButton,
+    globalErrors: Errors,
+    error: Error,
+  },
+  {
+    renderField: ({ Field, ...props }) => {
+      const { name, errors } = props
+
+      return (
+        <Field key={name} {...props}>
+          {({ Label, SmartInput, Errors }) => (
+            <>
+              <Label className={errors ? 'text-error' : undefined} />
+              <SmartInput className={errors ? 'input-error' : undefined} />
+              <Errors />
+            </>
+          )}
+        </Field>
+      )
+    },
+  }
+)
+
+const schema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  preferredSport: z.enum(['Basketball', 'Football', 'Other']),
+  newsletter: z.boolean().default(false),
+})
+
+export const loader = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <GlobalSchemaForm schema={schema} />
+    </Example>
+  )
+}

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -1271,6 +1271,60 @@ describe('renderForm', () => {
     expect(html).not.toContain('data-factory')
   })
 
+  it('works with makeSchemaForm factory-level renderField', () => {
+    const CustomSchemaForm = makeSchemaForm(defaultComponents, {
+      renderField: ({ Field, name, ...props }) => (
+        <div data-factory-field>
+          {/* biome-ignore lint/suspicious/noExplicitAny: test helper */}
+          <Field name={name} {...(props as any)} />
+        </div>
+      ),
+    })
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(<CustomSchemaForm schema={schema} />)
+
+    expect(html).toContain('data-factory-field')
+    expect(html).toContain('name="name"')
+  })
+
+  it('per-form renderField overrides factory-level', () => {
+    const CustomSchemaForm = makeSchemaForm(defaultComponents, {
+      renderField: ({ Field, name, ...props }) => (
+        <div data-factory-field>
+          {/* biome-ignore lint/suspicious/noExplicitAny: test helper */}
+          <Field name={name} {...(props as any)} />
+        </div>
+      ),
+    })
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(
+      <CustomSchemaForm
+        schema={schema}
+        renderField={({ Field, name, ...props }) => (
+          <div data-per-form-field>
+            {/* biome-ignore lint/suspicious/noExplicitAny: test helper */}
+            <Field name={name} {...(props as any)} />
+          </div>
+        )}
+      />
+    )
+
+    expect(html).toContain('data-per-form-field')
+    expect(html).not.toContain('data-factory-field')
+  })
+
+  it('uses defaultRenderField when no factory or per-form renderField', () => {
+    const CustomSchemaForm = makeSchemaForm(defaultComponents)
+    const schema = z.object({ name: z.string() })
+
+    const html = renderToStaticMarkup(<CustomSchemaForm schema={schema} />)
+
+    expect(html).toContain('name="name"')
+    expect(html).toContain('Name')
+  })
+
   it('uses pendingButtonLabel in buttonLabel when submitting', () => {
     const schema = z.object({ name: z.string() })
     const fetcher = {

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -341,6 +341,10 @@ function uiFieldType(info: SchemaInfo): FieldType {
  * @param options.renderForm - Default form layout function used when no
  *   `children` or per-form `renderForm` is provided. Receives the same
  *   helpers as `children` plus `fetcher`, `disabled` and `buttonLabel`.
+ * @param options.renderField - Default field rendering function used when no
+ *   per-form `renderField` is provided. Receives the `Field` component plus
+ *   field metadata. Each individual form can override this with its own
+ *   `renderField` prop.
  * @returns A SchemaForm component that uses the provided base components.
  *
  * @example
@@ -368,6 +372,18 @@ function uiFieldType(info: SchemaInfo): FieldType {
  *   }
  * )
  * ```
+ *
+ * @example
+ * ```tsx
+ * const SchemaForm = makeSchemaForm(
+ *   { input: MyInput },
+ *   {
+ *     renderField: ({ Field, name, ...props }) => (
+ *       <Field key={name} name={name} {...props} />
+ *     ),
+ *   }
+ * )
+ * ```
  */
 function makeSchemaForm<Base extends Partial<ComponentMap>>(
   base: Base,
@@ -379,9 +395,17 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(
       readonly never[],
       readonly never[]
     >
+    renderField?: RenderField<
+      FormSchema,
+      ResolveComponents<Base>,
+      readonly never[],
+      readonly never[],
+      readonly never[]
+    >
   }
 ) {
   const factoryRenderForm = options?.renderForm
+  const factoryRenderField = options?.renderField
   const mergedBase = { ...defaultComponents, ...base } as Record<
     string,
     // biome-ignore lint/suspicious/noExplicitAny: widen for internal JSX rendering — generics are for the external API
@@ -401,7 +425,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(
     fetcher,
     mode = 'onSubmit',
     reValidateMode = 'onChange',
-    renderField = defaultRenderField,
+    renderField: renderFieldProp,
     renderForm: renderFormProp,
     buttonLabel: rawButtonLabel = 'OK',
     pendingButtonLabel,
@@ -636,6 +660,10 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(
       // biome-ignore lint/suspicious/noExplicitAny: factory-level renderForm uses widened generics — type safety is enforced at the consumer level
       renderFormProp ?? (factoryRenderForm as any) ?? defaultRenderForm
 
+    const effectiveRenderField =
+      // biome-ignore lint/suspicious/noExplicitAny: factory-level renderField uses widened generics — type safety is enforced at the consumer level
+      renderFieldProp ?? (factoryRenderField as any) ?? defaultRenderField
+
     const childrenHelpers = {
       Field,
       Fields: FieldsSentinel,
@@ -679,7 +707,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(
           : (child.props.autoFocus ?? field?.autoFocus)
 
         if (!child.props.children && field) {
-          return renderField({
+          return effectiveRenderField({
             Field,
             ...field,
             ...child.props,
@@ -798,7 +826,7 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(
  * @param props.fetcher - Fetcher object returned by `useFetcher()`
  * @param props.mode - Validation trigger mode for React Hook Form
  * @param props.reValidateMode - Validation mode after submission
- * @param props.renderField - Custom field rendering function
+ * @param props.renderField - Custom field rendering function. Can also be set globally via `makeSchemaForm`
  * @param props.renderForm - Custom form layout function. Called when no `children` is provided. Receives the same helpers as `children` plus `fetcher`, `disabled` and `buttonLabel`. Can also be set globally via `makeSchemaForm`
  * @param props.buttonLabel - Text shown in the submit button
  * @param props.pendingButtonLabel - Text shown while submitting


### PR DESCRIPTION
## Summary
- Add `renderField` to the `options` parameter of `makeSchemaForm`, matching the existing `renderForm` factory pattern
- Per-form `renderField` prop overrides the factory default; falls back to `defaultRenderField` when neither is provided
- Add website example ("Global render field") demonstrating factory-level `renderField`

Closes #414

## Test plan
- [x] 3 new unit tests: factory-level used, per-form overrides factory, default fallback
- [x] New E2E Playwright spec with JS-enabled and JS-disabled tests
- [x] All existing tests pass (lint, tsc, 97 E2E + unit tests)