### PR TITLE
Auto-render hidden fields with custom children

### DIFF
--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -66,6 +66,7 @@ const testRoutes = [
   'field-with-radio-children',
   'field-with-ref',
   'fields-component',
+  'hidden-field-with-custom-children',
   'hidden-field-with-errors',
   'accented-options',
 ]

--- a/apps/web/app/routes/examples/form-with-children.tsx
+++ b/apps/web/app/routes/examples/form-with-children.tsx
@@ -22,10 +22,13 @@ const code = `const schema = z.object({
 })
 
 export default () => (
-  <SchemaForm schema={schema}>
+  <SchemaForm
+    schema={schema}
+    hiddenFields={['csrfToken']}
+    values={{ csrfToken: 'abc123' }}
+  >
     {({ Field, Errors, Button }) => (
       <>
-        <Field name="csrfToken" value="abc123" hidden />
         <Field name="firstName" placeholder="Your first name" />
         <Field name="email" label="E-mail" placeholder="Your e-mail" />
         <em>You'll hear from us at this address 👆🏽</em>
@@ -65,10 +68,13 @@ export const action = async ({ request }: Route.ActionArgs) =>
 export default function Component() {
   return (
     <Example title={title} description={description}>
-      <SchemaForm schema={schema}>
+      <SchemaForm
+        schema={schema}
+        hiddenFields={['csrfToken']}
+        values={{ csrfToken: 'abc123' }}
+      >
         {({ Field, Errors, Button }) => (
           <>
-            <Field name="csrfToken" value="abc123" hidden />
             <Field name="firstName" placeholder="Your first name" />
             <Field name="email" label="E-mail" placeholder="Your e-mail" />
             <em>You&apos;ll hear from us at this address 👆🏽</em>

--- a/apps/web/app/routes/tests/hidden-field-with-custom-children.spec.ts
+++ b/apps/web/app/routes/tests/hidden-field-with-custom-children.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test, testWithoutJS } from 'tests/setup/tests'
+
+const route = '/test-examples/hidden-field-with-custom-children'
+
+test('With JS enabled', async ({ example }) => {
+  const { firstName, button, page } = example
+  await page.goto(route)
+
+  // Render
+  await example.expectField(firstName)
+  await expect(button).toBeEnabled()
+
+  // Hidden field should be present in the DOM
+  await expect(
+    page.locator('input[name="csrfToken"][type="hidden"]')
+  ).toHaveCount(1)
+
+  // Client-side validation
+  await button.click()
+
+  await example.expectError(
+    firstName,
+    'Too small: expected string to have >=1 characters'
+  )
+
+  // Fill and submit
+  await firstName.input.fill('John')
+  await button.click()
+  await expect(button).toBeDisabled()
+  await example.expectData({
+    csrfToken: 'abc123',
+    firstName: 'John',
+  })
+})
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { firstName, button, page } = example
+  await page.goto(route)
+
+  // Hidden field should be present in the DOM
+  await expect(
+    page.locator('input[name="csrfToken"][type="hidden"]')
+  ).toHaveCount(1)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  await example.expectError(
+    firstName,
+    'Too small: expected string to have >=1 characters'
+  )
+
+  // Fill and submit
+  await firstName.input.fill('John')
+  await button.click()
+  await page.reload()
+
+  await example.expectData({
+    csrfToken: 'abc123',
+    firstName: 'John',
+  })
+})

--- a/apps/web/app/routes/tests/hidden-field-with-custom-children.tsx
+++ b/apps/web/app/routes/tests/hidden-field-with-custom-children.tsx
@@ -1,0 +1,48 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import { formAction } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/hidden-field-with-custom-children'
+
+const title = 'Hidden fields with custom children'
+const description =
+  'In this example, we ensure that hidden fields are rendered even when using custom children.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const schema = z.object({
+  csrfToken: z.string().min(1),
+  firstName: z.string().min(1),
+})
+
+export const loader = () => ({
+  code: hljs.highlight('', { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm
+        schema={schema}
+        hiddenFields={['csrfToken']}
+        values={{ csrfToken: 'abc123' }}
+      >
+        {({ Field, Errors, Button }) => (
+          <>
+            <Field name="firstName" />
+            <Errors />
+            <Button />
+          </>
+        )}
+      </SchemaForm>
+    </Example>
+  )
+}

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -313,6 +313,83 @@ describe('SchemaForm', () => {
     expect(html).toContain('type="hidden"')
   })
 
+  it('auto-renders hidden fields when custom children omit them', () => {
+    const schema = z.object({ visible: z.string(), secret: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        hiddenFields={['secret']}
+        values={{ secret: 'abc123' }}
+      >
+        {({ Field, Errors, Button }) => (
+          <>
+            <Field name="visible" />
+            <Errors />
+            <Button />
+          </>
+        )}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('name="visible"')
+    expect(html).toContain('name="secret"')
+    expect(html).toContain('type="hidden"')
+  })
+
+  it('does not duplicate hidden fields when manually rendered in children', () => {
+    const schema = z.object({ visible: z.string(), secret: z.string() })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        hiddenFields={['secret']}
+        values={{ secret: 'abc123' }}
+      >
+        {({ Field, Errors, Button }) => (
+          <>
+            <Field name="secret" />
+            <Field name="visible" />
+            <Errors />
+            <Button />
+          </>
+        )}
+      </SchemaForm>
+    )
+
+    const matches = html.match(/name="secret"/g)
+    expect(matches).toHaveLength(1)
+  })
+
+  it('auto-renders multiple hidden fields with custom children', () => {
+    const schema = z.object({
+      visible: z.string(),
+      token: z.string(),
+      nonce: z.string(),
+    })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        hiddenFields={['token', 'nonce']}
+        values={{ token: 'tok', nonce: 'non' }}
+      >
+        {({ Field, Errors, Button }) => (
+          <>
+            <Field name="visible" />
+            <Errors />
+            <Button />
+          </>
+        )}
+      </SchemaForm>
+    )
+
+    expect(html).toContain('name="token"')
+    expect(html).toContain('name="nonce"')
+    const hiddenInputs = html.match(/type="hidden"/g)
+    expect(hiddenInputs).toHaveLength(2)
+  })
+
   it('overrides labels and placeholders', () => {
     const schema = z.object({ name: z.string() })
 

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -697,7 +697,38 @@ function makeSchemaForm<Base extends Partial<ComponentMap>>(
       FieldsWrapper,
     })
 
-    const processedContent = mapChildren(expandedContent, (child) => {
+    const renderedFieldNames = reduceElements(
+      expandedContent,
+      new Set<string>(),
+      (set, child) => {
+        if (child.type === Field && child.props.name) {
+          set.add(String(child.props.name))
+        }
+        return set
+      }
+    )
+
+    const missingHiddenFields = (hiddenFields ?? []).filter(
+      (name) => !renderedFieldNames.has(String(name))
+    )
+
+    const contentWithHiddenFields =
+      missingHiddenFields.length > 0
+        ? React.createElement(
+            React.Fragment,
+            null,
+            expandedContent,
+            ...missingHiddenFields.map((name) =>
+              // biome-ignore lint/suspicious/noExplicitAny: Field identity varies per schema — generics are for the external API
+              React.createElement(Field as React.ComponentType<any>, {
+                key: String(name),
+                name: String(name),
+              })
+            )
+          )
+        : expandedContent
+
+    const processedContent = mapChildren(contentWithHiddenFields, (child) => {
       if (child.type === Field) {
         const { name } = child.props
         const field = makeField(name)


### PR DESCRIPTION
## Summary
- Hidden fields declared via `hiddenFields` prop are now automatically rendered even when users provide custom `children` without `<Fields />` or manual `<Field>` elements for those fields
- Duplicate hidden fields are prevented by scanning the existing tree before injection
- Updated the "Form with children" website example to use `hiddenFields` + `values` props instead of manual `<Field hidden />`

Closes #146

## Test plan
- [x] Unit tests: auto-render with custom children, no duplicates with manual Field, multiple hidden fields
- [x] E2E test route: `hidden-field-with-custom-children` (with and without JS)
- [x] `pnpm run lint` passes
- [x] `pnpm run tsc` passes
- [x] `pnpm run test` passes (234 tests, 16 files)
- [ ] Verify existing E2E tests for `form-with-children` still pass
- [ ] Verify `/test-examples/hidden-field-with-custom-children` in browser