### PR TITLE
Add create-remix-forms CLI

### DIFF
--- a/apps/web/app/routes/get-started.tsx
+++ b/apps/web/app/routes/get-started.tsx
@@ -232,8 +232,24 @@ export default function Component({ loaderData }: Route.ComponentProps) {
       <Code>{customInputCode}</Code>
       <SubHeading>[Optional] Customize styles</SubHeading>
       <p>
-        Remix Forms doesn&apos;t ship any styles, so you might want to configure
-        basic styles for your forms. Let&apos;s edit our custom{' '}
+        Remix Forms works out of the box with unstyled HTML elements, but
+        you&apos;ll probably want styled components. The easiest way is to use
+        our CLI:
+      </p>
+      <Pre>npx create-remix-forms</Pre>
+      <p>
+        It will scaffold a <em>schema-form</em> directory with styled components
+        for every slot. Two presets are available: <strong>Tailwind CSS</strong>{' '}
+        (plain utility classes) and <strong>DaisyUI</strong> (Tailwind + DaisyUI
+        component classes).
+      </p>
+      <p>You can also skip the prompts with flags:</p>
+      <Pre>
+        npx create-remix-forms --preset daisyui --output ./app/ui/schema-form
+      </Pre>
+      <SubHeading>[Alternative] Manual setup</SubHeading>
+      <p>
+        If you prefer to set things up manually, create a custom{' '}
         <em>SchemaForm</em> component:
       </p>
       <Code>{stylesCode}</Code>

--- a/biome.json
+++ b/biome.json
@@ -50,7 +50,7 @@
         "useSortedClasses": {
           "options": {
             "attributes": [],
-            "functions": ["cx"]
+            "functions": ["cx", "twMerge"]
           },
           "level": "warn",
           "fix": "safe"

--- a/packages/create-remix-forms/package.json
+++ b/packages/create-remix-forms/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "create-remix-forms",
+  "version": "0.1.0",
+  "description": "Scaffold styled components for remix-forms",
+  "type": "module",
+  "bin": {
+    "create-remix-forms": "./dist/index.js"
+  },
+  "files": ["dist"],
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "tsc": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.10.1",
+    "commander": "^13.1.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "5.8.3",
+    "vitest": "2.1.8"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/create-remix-forms/src/generate.test.ts
+++ b/packages/create-remix-forms/src/generate.test.ts
@@ -1,0 +1,228 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { generate } from './generate'
+import { slotDefinitions } from './presets/shared'
+import type { PresetName } from './types'
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'create-remix-forms-'))
+}
+
+function cleanup(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true })
+}
+
+describe('generate', () => {
+  const presets: PresetName[] = ['daisyui', 'tailwind']
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) cleanup(tempDir)
+  })
+
+  for (const preset of presets) {
+    describe(preset, () => {
+      it('creates the expected number of files', () => {
+        tempDir = makeTempDir()
+        const outputDir = path.join(tempDir, 'schema-form')
+        const files = generate({ preset, outputDir })
+
+        // 27 component files + 1 barrel
+        expect(files).toHaveLength(slotDefinitions.length + 1)
+      })
+
+      it('creates all component files and the barrel', () => {
+        tempDir = makeTempDir()
+        const outputDir = path.join(tempDir, 'schema-form')
+        generate({ preset, outputDir })
+
+        for (const slot of slotDefinitions) {
+          const filePath = path.join(outputDir, slot.fileName)
+          expect(fs.existsSync(filePath)).toBe(true)
+        }
+        expect(fs.existsSync(path.join(outputDir, 'index.ts'))).toBe(true)
+      })
+
+      it('barrel imports all components and calls makeSchemaForm', () => {
+        tempDir = makeTempDir()
+        const outputDir = path.join(tempDir, 'schema-form')
+        generate({ preset, outputDir })
+
+        const barrel = fs.readFileSync(
+          path.join(outputDir, 'index.ts'),
+          'utf-8'
+        )
+        expect(barrel).toContain("import { makeSchemaForm } from 'remix-forms'")
+        expect(barrel).toContain('export { SchemaForm }')
+
+        for (const slot of slotDefinitions) {
+          expect(barrel).toContain(`import ${slot.exportName} from`)
+          expect(barrel).toContain(`${slot.slotName}: ${slot.exportName}`)
+        }
+      })
+
+      it('creates the output directory recursively', () => {
+        tempDir = makeTempDir()
+        const outputDir = path.join(tempDir, 'deep', 'nested', 'schema-form')
+        const files = generate({ preset, outputDir })
+        expect(files.length).toBeGreaterThan(0)
+        expect(fs.existsSync(outputDir)).toBe(true)
+      })
+    })
+  }
+})
+
+describe('generate (daisyui-specific)', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) cleanup(tempDir)
+  })
+
+  it('uses DaisyUI classes in input component', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const input = fs.readFileSync(path.join(outputDir, 'input.tsx'), 'utf-8')
+    expect(input).toContain('input input-bordered w-full')
+  })
+
+  it('uses DaisyUI classes in button component', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const button = fs.readFileSync(path.join(outputDir, 'button.tsx'), 'utf-8')
+    expect(button).toContain('btn btn-primary')
+  })
+
+  it('uses twMerge for className merging', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const input = fs.readFileSync(path.join(outputDir, 'input.tsx'), 'utf-8')
+    expect(input).toContain("import { twMerge } from 'tailwind-merge'")
+    expect(input).toContain('twMerge(')
+  })
+})
+
+describe('generate (tailwind-specific)', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) cleanup(tempDir)
+  })
+
+  it('uses plain Tailwind classes instead of DaisyUI', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'tailwind', outputDir })
+
+    const input = fs.readFileSync(path.join(outputDir, 'input.tsx'), 'utf-8')
+    expect(input).not.toContain('input input-bordered')
+    expect(input).toContain('rounded-md')
+    expect(input).toContain('border-gray-300')
+  })
+
+  it('uses text-red-600 instead of text-error', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'tailwind', outputDir })
+
+    const error = fs.readFileSync(path.join(outputDir, 'error.tsx'), 'utf-8')
+    expect(error).not.toContain('text-error')
+    expect(error).toContain('text-red-600')
+  })
+})
+
+describe('generate (component patterns)', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) cleanup(tempDir)
+  })
+
+  it('form component uses ReactRouterForm alias', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const form = fs.readFileSync(path.join(outputDir, 'form.tsx'), 'utf-8')
+    expect(form).toContain(
+      "import { Form as ReactRouterForm } from 'react-router'"
+    )
+    expect(form).toContain('<ReactRouterForm')
+  })
+
+  it('input uses forwardRef with HTMLInputElement', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const input = fs.readFileSync(path.join(outputDir, 'input.tsx'), 'utf-8')
+    expect(input).toContain('React.forwardRef<')
+    expect(input).toContain('HTMLInputElement')
+    expect(input).toContain("type = 'text'")
+  })
+
+  it('multiline uses forwardRef with HTMLTextAreaElement', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const multiline = fs.readFileSync(
+      path.join(outputDir, 'multiline.tsx'),
+      'utf-8'
+    )
+    expect(multiline).toContain('HTMLTextAreaElement')
+    expect(multiline).toContain('<textarea')
+    expect(multiline).toContain('rows={5}')
+  })
+
+  it('select uses forwardRef with HTMLSelectElement', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const select = fs.readFileSync(path.join(outputDir, 'select.tsx'), 'utf-8')
+    expect(select).toContain('HTMLSelectElement')
+    expect(select).toContain('<select')
+  })
+
+  it('add/remove buttons have type="button"', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const add = fs.readFileSync(path.join(outputDir, 'add-button.tsx'), 'utf-8')
+    const remove = fs.readFileSync(
+      path.join(outputDir, 'remove-button.tsx'),
+      'utf-8'
+    )
+    expect(add).toContain("type = 'button'")
+    expect(remove).toContain("type = 'button'")
+  })
+
+  it('label does not include linter-specific comments', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const label = fs.readFileSync(path.join(outputDir, 'label.tsx'), 'utf-8')
+    expect(label).not.toContain('biome-ignore')
+  })
+
+  it('submit button is wrapped in a div', () => {
+    tempDir = makeTempDir()
+    const outputDir = path.join(tempDir, 'schema-form')
+    generate({ preset: 'daisyui', outputDir })
+
+    const button = fs.readFileSync(path.join(outputDir, 'button.tsx'), 'utf-8')
+    expect(button).toContain('<div className="flex justify-end">')
+    expect(button).toContain('<button')
+  })
+})

--- a/packages/create-remix-forms/src/generate.ts
+++ b/packages/create-remix-forms/src/generate.ts
@@ -1,0 +1,37 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { renderBarrel } from './presets/barrel'
+import { getPreset } from './presets/index'
+import { slotDefinitions } from './presets/shared'
+import { renderSlot } from './presets/templates'
+import type { PresetName } from './types'
+
+type GenerateOptions = {
+  preset: PresetName
+  outputDir: string
+}
+
+function generate({ preset, outputDir }: GenerateOptions): string[] {
+  const config = getPreset(preset)
+  const resolvedDir = path.resolve(outputDir)
+  const createdFiles: string[] = []
+
+  fs.mkdirSync(resolvedDir, { recursive: true })
+
+  for (const slot of slotDefinitions) {
+    const filePath = path.join(resolvedDir, slot.fileName)
+    const content = renderSlot(slot, config.classes)
+    fs.writeFileSync(filePath, content, 'utf-8')
+    createdFiles.push(filePath)
+  }
+
+  const barrelPath = path.join(resolvedDir, 'index.ts')
+  const barrelContent = renderBarrel(slotDefinitions)
+  fs.writeFileSync(barrelPath, barrelContent, 'utf-8')
+  createdFiles.push(barrelPath)
+
+  return createdFiles
+}
+
+export { generate }
+export type { GenerateOptions }

--- a/packages/create-remix-forms/src/index.ts
+++ b/packages/create-remix-forms/src/index.ts
@@ -1,0 +1,110 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as p from '@clack/prompts'
+import { Command } from 'commander'
+import { generate } from './generate'
+import { presetNames } from './presets/index'
+import { installDependencies } from './presets/install'
+import type { PresetName } from './types'
+
+const version = '0.1.0'
+
+type Options = {
+  preset?: string
+  output: string
+  yes?: boolean
+}
+
+const program = new Command()
+  .name('create-remix-forms')
+  .description('Scaffold styled components for remix-forms')
+  .version(version)
+  .option('--preset <name>', 'Preset to use: tailwind | daisyui')
+  .option(
+    '--output <path>',
+    'Output directory for generated components',
+    './app/ui/schema-form'
+  )
+  .option('-y, --yes', 'Skip confirmation prompts')
+  .action(async (options: Options) => {
+    p.intro('create-remix-forms')
+
+    let preset: PresetName
+
+    if (options.preset && presetNames.includes(options.preset as PresetName)) {
+      preset = options.preset as PresetName
+    } else {
+      const result = await p.select({
+        message: 'Which preset would you like to use?',
+        options: [
+          {
+            value: 'tailwind' as const,
+            label: 'Tailwind CSS',
+            hint: 'Plain utility classes',
+          },
+          {
+            value: 'daisyui' as const,
+            label: 'DaisyUI',
+            hint: 'Tailwind + DaisyUI component classes',
+          },
+        ],
+      })
+      if (p.isCancel(result)) {
+        p.cancel('Cancelled.')
+        process.exit(0)
+      }
+      preset = result
+    }
+
+    let outputDir = options.output
+
+    if (!options.preset) {
+      const result = await p.text({
+        message: 'Where should we create the components?',
+        placeholder: './app/ui/schema-form',
+        defaultValue: outputDir,
+        validate: (v) => {
+          if (!v.trim()) return 'Path cannot be empty'
+        },
+      })
+      if (p.isCancel(result)) {
+        p.cancel('Cancelled.')
+        process.exit(0)
+      }
+      outputDir = result
+    }
+
+    const resolved = path.resolve(outputDir)
+    if (fs.existsSync(resolved) && !options.yes) {
+      const overwrite = await p.confirm({
+        message: `Directory ${outputDir} already exists. Overwrite?`,
+      })
+      if (p.isCancel(overwrite) || !overwrite) {
+        p.cancel('Cancelled.')
+        process.exit(0)
+      }
+    }
+
+    const s = p.spinner()
+
+    s.start('Installing remix-forms and tailwind-merge...')
+    try {
+      installDependencies(process.cwd())
+      s.stop('Installed remix-forms and tailwind-merge')
+    } catch {
+      s.stop('Could not auto-install dependencies')
+      p.log.warn(
+        'Please install manually: npm install remix-forms tailwind-merge'
+      )
+    }
+
+    s.start('Generating components...')
+    const files = generate({ preset, outputDir })
+    s.stop(`Created ${files.length} files in ${outputDir}`)
+
+    p.note(`import { SchemaForm } from '${outputDir}'`, 'Next step')
+
+    p.outro('Done! Happy form building.')
+  })
+
+program.parse()

--- a/packages/create-remix-forms/src/presets/barrel.ts
+++ b/packages/create-remix-forms/src/presets/barrel.ts
@@ -1,0 +1,28 @@
+import type { SlotDefinition } from '../types'
+
+function renderBarrel(slots: SlotDefinition[]): string {
+  const sorted = [...slots].sort((a, b) => a.fileName.localeCompare(b.fileName))
+
+  const imports = sorted
+    .map((s) => {
+      const moduleName = s.fileName.replace('.tsx', '')
+      return `import ${s.exportName} from './${moduleName}'`
+    })
+    .join('\n')
+
+  const entries = slots
+    .map((s) => `  ${s.slotName}: ${s.exportName},`)
+    .join('\n')
+
+  return `import { makeSchemaForm } from 'remix-forms'
+${imports}
+
+const SchemaForm = makeSchemaForm({
+${entries}
+})
+
+export { SchemaForm }
+`
+}
+
+export { renderBarrel }

--- a/packages/create-remix-forms/src/presets/daisyui.ts
+++ b/packages/create-remix-forms/src/presets/daisyui.ts
@@ -1,0 +1,39 @@
+import type { PresetConfig } from '../types'
+
+const daisyui: PresetConfig = {
+  name: 'daisyui',
+  displayName: 'DaisyUI',
+  description: 'Tailwind CSS + DaisyUI component classes',
+  classes: {
+    form: 'flex flex-col gap-6',
+    fields: 'flex flex-col gap-6',
+    field: 'flex flex-col gap-2',
+    label: 'label',
+    input: 'input input-bordered w-full',
+    multiline: 'textarea textarea-bordered w-full',
+    select: 'select select-bordered w-full',
+    checkbox: 'checkbox checkbox-primary',
+    fileInput: 'file-input file-input-bordered w-full',
+    radio: 'radio radio-primary',
+    radioGroup: 'flex gap-4',
+    radioLabel: 'label flex cursor-pointer items-center gap-2',
+    checkboxLabel: 'label flex cursor-pointer items-center gap-2',
+    fieldErrors: 'flex flex-col gap-2 text-center',
+    globalErrors: 'flex flex-col gap-2 text-center',
+    error: 'text-error text-sm',
+    button: 'btn btn-primary',
+    buttonWrapper: 'flex justify-end',
+    scalarArrayField: 'flex flex-1 flex-col gap-2',
+    scalarArrayItem: 'flex items-center gap-2',
+    objectArrayItem: 'flex flex-col gap-2',
+    arrayArrayItem: 'flex flex-col gap-2',
+    addButton: 'btn btn-outline btn-sm mt-2 self-start',
+    removeButton: 'btn btn-ghost btn-sm text-error',
+    arrayEmpty: 'py-2 text-base-content/50 text-sm',
+    arrayTitle: 'label',
+    objectTitle: 'label',
+    objectFields: 'flex flex-col gap-4 border-l-2 border-base-100 pl-4',
+  },
+}
+
+export { daisyui }

--- a/packages/create-remix-forms/src/presets/index.ts
+++ b/packages/create-remix-forms/src/presets/index.ts
@@ -1,0 +1,16 @@
+import type { PresetConfig, PresetName } from '../types'
+import { daisyui } from './daisyui'
+import { tailwind } from './tailwind'
+
+const presets: Record<PresetName, PresetConfig> = {
+  tailwind,
+  daisyui,
+}
+
+const presetNames = Object.keys(presets) as PresetName[]
+
+function getPreset(name: PresetName): PresetConfig {
+  return presets[name]
+}
+
+export { presets, presetNames, getPreset }

--- a/packages/create-remix-forms/src/presets/install.ts
+++ b/packages/create-remix-forms/src/presets/install.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+
+function detectPackageManager(cwd: string): PackageManager {
+  if (fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (fs.existsSync(path.join(cwd, 'bun.lockb'))) return 'bun'
+  if (fs.existsSync(path.join(cwd, 'yarn.lock'))) return 'yarn'
+  return 'npm'
+}
+
+function installDependencies(cwd: string): void {
+  const pm = detectPackageManager(cwd)
+  const packages = 'remix-forms@latest tailwind-merge@latest'
+
+  const commands: Record<PackageManager, string> = {
+    pnpm: `pnpm add ${packages}`,
+    npm: `npm install ${packages}`,
+    yarn: `yarn add ${packages}`,
+    bun: `bun add ${packages}`,
+  }
+
+  execSync(commands[pm], { cwd, stdio: 'pipe' })
+}
+
+export { detectPackageManager, installDependencies }

--- a/packages/create-remix-forms/src/presets/shared.ts
+++ b/packages/create-remix-forms/src/presets/shared.ts
@@ -1,0 +1,173 @@
+import type { SlotDefinition } from '../types'
+
+const slotDefinitions: SlotDefinition[] = [
+  {
+    slotName: 'form',
+    fileName: 'form.tsx',
+    exportName: 'Form',
+    pattern: 'form',
+  },
+  {
+    slotName: 'fields',
+    fileName: 'fields.tsx',
+    exportName: 'Fields',
+    pattern: 'function-div',
+  },
+  {
+    slotName: 'field',
+    fileName: 'field.tsx',
+    exportName: 'Field',
+    pattern: 'function-div',
+  },
+  {
+    slotName: 'label',
+    fileName: 'label.tsx',
+    exportName: 'Label',
+    pattern: 'function-label',
+  },
+  {
+    slotName: 'input',
+    fileName: 'input.tsx',
+    exportName: 'Input',
+    pattern: 'forwardRef-input',
+    defaultProps: { type: "'text'" },
+  },
+  {
+    slotName: 'multiline',
+    fileName: 'multiline.tsx',
+    exportName: 'Multiline',
+    pattern: 'forwardRef-textarea',
+  },
+  {
+    slotName: 'select',
+    fileName: 'select.tsx',
+    exportName: 'Select',
+    pattern: 'forwardRef-select',
+  },
+  {
+    slotName: 'checkbox',
+    fileName: 'checkbox.tsx',
+    exportName: 'Checkbox',
+    pattern: 'forwardRef-input',
+    defaultProps: { type: "'checkbox'" },
+  },
+  {
+    slotName: 'fileInput',
+    fileName: 'file-input.tsx',
+    exportName: 'FileInput',
+    pattern: 'forwardRef-input',
+  },
+  {
+    slotName: 'radio',
+    fileName: 'radio.tsx',
+    exportName: 'Radio',
+    pattern: 'forwardRef-input',
+    defaultProps: { type: "'radio'" },
+  },
+  {
+    slotName: 'radioGroup',
+    fileName: 'radio-group.tsx',
+    exportName: 'RadioGroup',
+    pattern: 'function-fieldset',
+  },
+  {
+    slotName: 'radioLabel',
+    fileName: 'radio-label.tsx',
+    exportName: 'RadioLabel',
+    pattern: 'function-label',
+  },
+  {
+    slotName: 'checkboxLabel',
+    fileName: 'checkbox-label.tsx',
+    exportName: 'CheckboxLabel',
+    pattern: 'function-label',
+  },
+  {
+    slotName: 'fieldErrors',
+    fileName: 'field-errors.tsx',
+    exportName: 'FieldErrors',
+    pattern: 'function-div',
+  },
+  {
+    slotName: 'globalErrors',
+    fileName: 'global-errors.tsx',
+    exportName: 'GlobalErrors',
+    pattern: 'function-div',
+  },
+  {
+    slotName: 'error',
+    fileName: 'error.tsx',
+    exportName: 'Error',
+    pattern: 'function-div',
+  },
+  {
+    slotName: 'button',
+    fileName: 'button.tsx',
+    exportName: 'Button',
+    pattern: 'button-wrapped',
+  },
+  {
+    slotName: 'scalarArrayField',
+    fileName: 'scalar-array-field.tsx',
+    exportName: 'ScalarArrayField',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'scalarArrayItem',
+    fileName: 'scalar-array-item.tsx',
+    exportName: 'ScalarArrayItem',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'objectArrayItem',
+    fileName: 'object-array-item.tsx',
+    exportName: 'ObjectArrayItem',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'arrayArrayItem',
+    fileName: 'array-array-item.tsx',
+    exportName: 'ArrayArrayItem',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'addButton',
+    fileName: 'add-button.tsx',
+    exportName: 'AddButton',
+    pattern: 'forwardRef-button',
+    defaultProps: { type: "'button'" },
+  },
+  {
+    slotName: 'removeButton',
+    fileName: 'remove-button.tsx',
+    exportName: 'RemoveButton',
+    pattern: 'forwardRef-button',
+    defaultProps: { type: "'button'" },
+  },
+  {
+    slotName: 'arrayEmpty',
+    fileName: 'array-empty.tsx',
+    exportName: 'ArrayEmpty',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'arrayTitle',
+    fileName: 'array-title.tsx',
+    exportName: 'ArrayTitle',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'objectTitle',
+    fileName: 'object-title.tsx',
+    exportName: 'ObjectTitle',
+    pattern: 'forwardRef-div',
+  },
+  {
+    slotName: 'objectFields',
+    fileName: 'object-fields.tsx',
+    exportName: 'ObjectFields',
+    pattern: 'forwardRef-div',
+  },
+]
+
+export { slotDefinitions }

--- a/packages/create-remix-forms/src/presets/tailwind.ts
+++ b/packages/create-remix-forms/src/presets/tailwind.ts
@@ -1,0 +1,47 @@
+import type { PresetConfig } from '../types'
+
+const tailwind: PresetConfig = {
+  name: 'tailwind',
+  displayName: 'Tailwind CSS',
+  description: 'Plain Tailwind CSS utility classes',
+  classes: {
+    form: 'flex flex-col gap-6',
+    fields: 'flex flex-col gap-6',
+    field: 'flex flex-col gap-2',
+    label: 'text-sm font-semibold text-gray-700',
+    input:
+      'w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500',
+    multiline:
+      'w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500',
+    select:
+      'w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500',
+    checkbox:
+      'size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500',
+    fileInput:
+      'w-full rounded-md border border-gray-300 text-sm file:mr-4 file:rounded-l-md file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100',
+    radio: 'size-4 border-gray-300 text-blue-600 focus:ring-blue-500',
+    radioGroup: 'flex gap-4',
+    radioLabel: 'flex cursor-pointer items-center gap-2 text-sm',
+    checkboxLabel: 'flex cursor-pointer items-center gap-2 text-sm',
+    fieldErrors: 'flex flex-col gap-1 text-center',
+    globalErrors: 'flex flex-col gap-1 text-center',
+    error: 'text-sm text-red-600',
+    button:
+      'rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50',
+    buttonWrapper: 'flex justify-end',
+    scalarArrayField: 'flex flex-1 flex-col gap-2',
+    scalarArrayItem: 'flex items-center gap-2',
+    objectArrayItem: 'flex flex-col gap-2',
+    arrayArrayItem: 'flex flex-col gap-2',
+    addButton:
+      'mt-2 self-start rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50',
+    removeButton:
+      'rounded-md px-2 py-1 text-sm font-medium text-red-600 hover:bg-red-50',
+    arrayEmpty: 'py-2 text-sm text-gray-400',
+    arrayTitle: 'text-sm font-semibold text-gray-700',
+    objectTitle: 'text-sm font-semibold text-gray-700',
+    objectFields: 'flex flex-col gap-4 border-l-2 border-gray-200 pl-4',
+  },
+}
+
+export { tailwind }

--- a/packages/create-remix-forms/src/presets/templates.ts
+++ b/packages/create-remix-forms/src/presets/templates.ts
@@ -1,0 +1,265 @@
+import type { ButtonClassMap, SlotDefinition } from '../types'
+
+function renderSlot(def: SlotDefinition, classes: ButtonClassMap): string {
+  switch (def.pattern) {
+    case 'form':
+      return renderForm(def, classes)
+    case 'forwardRef-input':
+      return renderForwardRefInput(def, classes)
+    case 'forwardRef-textarea':
+      return renderForwardRefTextarea(def, classes)
+    case 'forwardRef-select':
+      return renderForwardRefSelect(def, classes)
+    case 'forwardRef-div':
+      return renderForwardRefDiv(def, classes)
+    case 'forwardRef-button':
+      return renderForwardRefButton(def, classes)
+    case 'function-div':
+      return renderFunctionDiv(def, classes)
+    case 'function-label':
+      return renderFunctionLabel(def, classes)
+    case 'function-fieldset':
+      return renderFunctionFieldset(def, classes)
+    case 'button-wrapped':
+      return renderButtonWrapped(def, classes)
+  }
+}
+
+function renderForm(def: SlotDefinition, classes: ButtonClassMap): string {
+  return `import * as React from 'react'
+import { Form as ReactRouterForm } from 'react-router'
+import { twMerge } from 'tailwind-merge'
+
+const ${def.exportName} = React.forwardRef<
+  HTMLFormElement,
+  React.ComponentPropsWithRef<typeof ReactRouterForm>
+>(({ className, ...props }, ref) => (
+  <ReactRouterForm
+    ref={ref}
+    className={twMerge('${classes[def.slotName]}', className)}
+    {...props}
+  />
+))
+
+export default ${def.exportName}
+`
+}
+
+function renderForwardRefInput(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  const defaultPropsDestructure = def.defaultProps
+    ? Object.entries(def.defaultProps)
+        .map(([key, value]) => `${key} = ${value}`)
+        .join(', ')
+    : null
+
+  const destructure = defaultPropsDestructure
+    ? `{ ${defaultPropsDestructure}, className, ...props }`
+    : '{ className, ...props }'
+
+  const defaultPropsJsx = def.defaultProps
+    ? Object.keys(def.defaultProps)
+        .map((key) => `\n    ${key}={${key}}`)
+        .join('')
+    : ''
+
+  return `import * as React from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const ${def.exportName} = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>((${destructure}, ref) => (
+  <input
+    ref={ref}${defaultPropsJsx}
+    className={twMerge('${classes[def.slotName]}', className)}
+    {...props}
+  />
+))
+
+export default ${def.exportName}
+`
+}
+
+function renderForwardRefTextarea(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import * as React from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const ${def.exportName} = React.forwardRef<
+  HTMLTextAreaElement,
+  JSX.IntrinsicElements['textarea']
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={twMerge('${classes[def.slotName]}', className)}
+    rows={5}
+    {...props}
+  />
+))
+
+export default ${def.exportName}
+`
+}
+
+function renderForwardRefSelect(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import * as React from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const ${def.exportName} = React.forwardRef<
+  HTMLSelectElement,
+  JSX.IntrinsicElements['select']
+>(({ className, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={twMerge('${classes[def.slotName]}', className)}
+    {...props}
+  />
+))
+
+export default ${def.exportName}
+`
+}
+
+function renderForwardRefDiv(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import * as React from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const ${def.exportName} = React.forwardRef<
+  HTMLDivElement,
+  JSX.IntrinsicElements['div']
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={twMerge('${classes[def.slotName]}', className)}
+    {...props}
+  />
+))
+
+export default ${def.exportName}
+`
+}
+
+function renderForwardRefButton(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  const defaultPropsDestructure = def.defaultProps
+    ? Object.entries(def.defaultProps)
+        .map(([key, value]) => `${key} = ${value}`)
+        .join(', ')
+    : null
+
+  const destructure = defaultPropsDestructure
+    ? `{ ${defaultPropsDestructure}, className, ...props }`
+    : '{ className, ...props }'
+
+  const defaultPropsJsx = def.defaultProps
+    ? Object.keys(def.defaultProps)
+        .map((key) => `\n    ${key}={${key}}`)
+        .join('')
+    : ''
+
+  return `import * as React from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const ${def.exportName} = React.forwardRef<
+  HTMLButtonElement,
+  JSX.IntrinsicElements['button']
+>((${destructure}, ref) => (
+  <button
+    ref={ref}${defaultPropsJsx}
+    className={twMerge('${classes[def.slotName]}', className)}
+    {...props}
+  />
+))
+
+export default ${def.exportName}
+`
+}
+
+function renderFunctionDiv(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import { twMerge } from 'tailwind-merge'
+
+export default function ${def.exportName}({
+  className,
+  ...props
+}: JSX.IntrinsicElements['div']) {
+  return <div className={twMerge('${classes[def.slotName]}', className)} {...props} />
+}
+`
+}
+
+function renderFunctionLabel(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import { twMerge } from 'tailwind-merge'
+
+export default function ${def.exportName}({
+  className,
+  ...props
+}: JSX.IntrinsicElements['label']) {
+  return (
+    <label className={twMerge('${classes[def.slotName]}', className)} {...props} />
+  )
+}
+`
+}
+
+function renderFunctionFieldset(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import { twMerge } from 'tailwind-merge'
+
+export default function ${def.exportName}({
+  className,
+  ...props
+}: JSX.IntrinsicElements['fieldset']) {
+  return (
+    <fieldset
+      className={twMerge('${classes[def.slotName]}', className)}
+      {...props}
+    />
+  )
+}
+`
+}
+
+function renderButtonWrapped(
+  def: SlotDefinition,
+  classes: ButtonClassMap
+): string {
+  return `import { twMerge } from 'tailwind-merge'
+
+export default function ${def.exportName}({
+  className,
+  ...props
+}: JSX.IntrinsicElements['button']) {
+  return (
+    <div className="${classes.buttonWrapper}">
+      <button
+        className={twMerge('${classes[def.slotName]}', className)}
+        {...props}
+      />
+    </div>
+  )
+}
+`
+}
+
+export { renderSlot }

--- a/packages/create-remix-forms/src/types.ts
+++ b/packages/create-remix-forms/src/types.ts
@@ -1,0 +1,77 @@
+type PresetName = 'tailwind' | 'daisyui'
+
+type SlotName =
+  | 'form'
+  | 'fields'
+  | 'field'
+  | 'label'
+  | 'input'
+  | 'multiline'
+  | 'select'
+  | 'checkbox'
+  | 'fileInput'
+  | 'radio'
+  | 'radioGroup'
+  | 'radioLabel'
+  | 'checkboxLabel'
+  | 'fieldErrors'
+  | 'globalErrors'
+  | 'error'
+  | 'button'
+  | 'scalarArrayField'
+  | 'scalarArrayItem'
+  | 'objectArrayItem'
+  | 'arrayArrayItem'
+  | 'addButton'
+  | 'removeButton'
+  | 'arrayEmpty'
+  | 'arrayTitle'
+  | 'objectTitle'
+  | 'objectFields'
+
+type SlotPattern =
+  | 'forwardRef-input'
+  | 'forwardRef-textarea'
+  | 'forwardRef-select'
+  | 'forwardRef-div'
+  | 'forwardRef-button'
+  | 'function-div'
+  | 'function-label'
+  | 'function-fieldset'
+  | 'form'
+  | 'button-wrapped'
+
+type SlotDefinition = {
+  slotName: SlotName
+  fileName: string
+  exportName: string
+  pattern: SlotPattern
+  defaultProps?: Record<string, string>
+}
+
+type ClassMap = Record<SlotName, string>
+
+type ButtonClassMap = ClassMap & { buttonWrapper: string }
+
+type PresetConfig = {
+  name: PresetName
+  displayName: string
+  description: string
+  classes: ButtonClassMap
+}
+
+type SlotTemplate = {
+  fileName: string
+  content: string
+}
+
+export type {
+  PresetName,
+  SlotName,
+  SlotPattern,
+  SlotDefinition,
+  ClassMap,
+  ButtonClassMap,
+  PresetConfig,
+  SlotTemplate,
+}

--- a/packages/create-remix-forms/tsconfig.json
+++ b/packages/create-remix-forms/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/packages/create-remix-forms/tsup.config.ts
+++ b/packages/create-remix-forms/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node20',
+  clean: true,
+  banner: { js: '#!/usr/bin/env node' },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,25 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  packages/create-remix-forms:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.10.1
+        version: 0.10.1
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+    devDependencies:
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 2.1.8
+        version: 2.1.8(@types/node@22.19.15)(lightningcss@1.32.0)
+
   packages/remix-forms:
     dependencies:
       '@hookform/resolvers':
@@ -387,6 +406,12 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@clack/core@0.4.2':
+    resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
+
+  '@clack/prompts@0.10.1':
+    resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1658,6 +1683,10 @@ packages:
   coerce-form-data@3.0.0:
     resolution: {integrity: sha512-s2VCwu4kkFQAJAvCDSp16ki7wAlGpmvedPX1MjOlyE6GkaqwbE1CC+6M6PQNz3QJ7+IR/hnPRnbdgcGnZZpKEQ==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -2405,6 +2434,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2964,6 +2996,17 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@clack/core@0.4.2':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.10.1':
+    dependencies:
+      '@clack/core': 0.4.2
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3938,6 +3981,8 @@ snapshots:
 
   coerce-form-data@3.0.0: {}
 
+  commander@13.1.0: {}
+
   commander@4.1.1: {}
 
   composable-functions@5.0.0: {}
@@ -4685,6 +4730,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

- Adds `create-remix-forms` package — a CLI that scaffolds styled components for `makeSchemaForm`
- Two presets: **Tailwind CSS** (plain utility classes) and **DaisyUI** (Tailwind + DaisyUI component classes)
- Generates 27 individual component files + barrel `index.ts` in a configurable output directory
- Interactive prompts via `@clack/prompts` with flag overrides (`--preset`, `--output`, `-y`) for CI
- Auto-installs `remix-forms` and `tailwind-merge` (detects pnpm/npm/yarn/bun)
- All generated components use `twMerge` for className merging
- Updates get-started page to recommend the CLI for styling setup
- Adds `twMerge` to Biome's `useSortedClasses.functions`

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run tsc` passes
- [x] `pnpm run test` passes (20 new CLI tests + 300 unit + 110 E2E)
- [x] Manual test: `node packages/create-remix-forms/dist/index.js --preset daisyui --output /tmp/test -y`
- [x] Manual test: `node packages/create-remix-forms/dist/index.js --preset tailwind --output /tmp/test -y`
- [x] CI passes

Closes #419